### PR TITLE
feat: undo command & diagnostics

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Environment (please complete the following information):**
  - OS: [e.g. Windows]
- - Lithos Version [e.g. 0.12.0]
+ - Lithos Version [e.g. 0.2.0]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/workflows/branch-enforcer.yml
+++ b/.github/workflows/branch-enforcer.yml
@@ -1,0 +1,15 @@
+name: 'Source Branch Enforcer'
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check_source_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify dev is the source
+        if: github.base_ref == 'main' && github.head_ref != 'dev'
+        run: |
+          echo "ERROR: Merges to 'main' are only allowed from the 'dev' branch."
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: read
+
 jobs:
   windows:
     runs-on: windows-latest
@@ -109,13 +112,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [windows, macos, linux]
+    permissions:
+      contents: write
     steps:
       - name: Download binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           # TODO: remove and add body_path once we have an automated release notes generator
           draft: true

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,34 +1,49 @@
 #!/usr/bin/env sh
-# Auto-format staged Rust files with rustfmt.
+# Auto-format staged Rust files with rustfmt and gate Rust/Cargo commits on
+# workspace clippy.
 #
 # Strategy: run `cargo fmt --all` once, then re-stage any Rust files that
 # were already in the index. This keeps the commit moving (the user said
 # they can't be bothered to run fmt manually) while avoiding partial
 # half-formatted commits.
 #
-# We only run when at least one .rs file is staged so we don't pay the
-# cargo-fmt startup cost on every docs / yaml / toml commit.
+# We only run when at least one Rust/Cargo-relevant file is staged so we don't
+# pay the cargo startup cost on every docs / yaml / md commit.
 
 set -e
 
-# Collect staged Rust files (Added/Copied/Modified/Renamed).
-staged_rs=$(git diff --cached --name-only --diff-filter=ACMR -- '*.rs' || true)
+# Collect staged paths (Added/Copied/Modified/Renamed).
+staged_paths=$(git diff --cached --name-only --diff-filter=ACMR || true)
 
-if [ -z "$staged_rs" ]; then
+if [ -z "$staged_paths" ]; then
   exit 0
 fi
+
+# Only gate commits that touch Rust or Cargo-related files.
+relevant_paths=$(printf '%s\n' "$staged_paths" | grep -E '(^|/).*\.rs$|(^|/)(Cargo\.toml|Cargo\.lock|rust-toolchain\.toml)$' || true)
+
+if [ -z "$relevant_paths" ]; then
+  exit 0
+fi
+
+staged_rs=$(printf '%s\n' "$staged_paths" | grep -E '(^|/).*\.rs$' || true)
 
 if ! command -v cargo >/dev/null 2>&1; then
-  echo "pre-commit: cargo not on PATH; skipping rustfmt." >&2
-  exit 0
+  echo "pre-commit: cargo is required for Rust/Cargo commits." >&2
+  exit 1
 fi
 
-echo "pre-commit: running cargo fmt on the workspace..."
-cargo fmt --all
+if [ -n "$staged_rs" ]; then
+  echo "pre-commit: running cargo fmt on the workspace..."
+  cargo fmt --all
 
-# Re-stage any of the originally-staged files that fmt touched.
-echo "$staged_rs" | while IFS= read -r f; do
-  [ -n "$f" ] || continue
-  [ -f "$f" ] || continue
-  git add -- "$f"
-done
+  # Re-stage any of the originally-staged files that fmt touched.
+  echo "$staged_rs" | while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    [ -f "$f" ] || continue
+    git add -- "$f"
+  done
+fi
+
+echo "pre-commit: running cargo clippy on the workspace..."
+cargo clippy --workspace --all-targets -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,7 +1916,7 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lithos"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap 2.34.0",
  "crossterm 0.28.1",

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -13,7 +13,7 @@ fallbacks.
 | `mantle.yml`              | `lithos.yml`                | Both are read; `lithos.yml` wins          |
 | `.mantle-state.yml`       | `.lithos-state.yml`         | Both are read; `lithos`-named wins        |
 | `<key>.mantle-state.yml`  | `<key>.lithos-state.yml`    | Same fallback for remote S3 keys          |
-| `MANTLE_OPEN_CLOUD_API_KEY` | `LITHOS_OPEN_CLOUD_API_KEY` | Both honored; `LITHOS_*` wins             |
+| `MANTLE_OPEN_CLOUD_API_KEY` | `LITHOS_OPEN_CLOUD_API_KEY` | Both honored; `LITHOS_*` wins. `ROBLOX_OPEN_CLOUD_API_KEY` is also accepted as an alias. |
 | `MANTLE_AWS_ACCESS_KEY_ID`  | `LITHOS_AWS_ACCESS_KEY_ID`  | Both honored; `LITHOS_*` wins             |
 | `MANTLE_AWS_SECRET_ACCESS_KEY` | `LITHOS_AWS_SECRET_ACCESS_KEY` | Both honored; `LITHOS_*` wins        |
 | `MANTLE_AWS_INHERIT_IAM_ROLE` | `LITHOS_AWS_INHERIT_IAM_ROLE` | Both honored                          |
@@ -24,8 +24,10 @@ When Lithos loads a project that uses the legacy names it logs a `warning:` line
 the next save:
 
 - **State files** are written under the new `.lithos-state.yml` name. The legacy
-  `.mantle-state.yml` file is left in place so that you can recover or roll back. After verifying
-  the new file is correct, you can delete the legacy file.
+  `.mantle-state.yml` file is left in place so that you can recover or roll back. New Lithos
+  writes use the v7 format, which stores both the current environment graph and recent deployment
+  checkpoints for `lithos undo`. After verifying the new file is correct, you can delete the legacy
+  file.
 - **Remote state** keys are written to `<key>.lithos-state.yml`. The legacy object remains in S3
   until you delete it.
 - **Project config** is never rewritten by Lithos; rename `mantle.yml` to `lithos.yml` at your
@@ -36,7 +38,8 @@ the next save:
 1. Update your CI to invoke `lithos` instead of `mantle`.
 2. Rename `mantle.yml` → `lithos.yml`.
 3. Set `LITHOS_OPEN_CLOUD_API_KEY` and `LITHOS_AWS_*` secrets alongside (or instead of) the
-   legacy `MANTLE_*` ones.
+  legacy `MANTLE_*` ones. Lithos also accepts `ROBLOX_OPEN_CLOUD_API_KEY`, but `LITHOS_*` is the
+  preferred name in project docs and CI.
 4. Run `lithos deploy` once. Confirm a fresh `.lithos-state.yml` (or remote object) is produced.
 5. Delete the legacy `.mantle-state.yml` after verifying the new state.
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ cargo clippy -- -D warnings
 cargo fmt
 ```
 
+Run `pnpm install` once at the repo root to enable the versioned Husky git
+hooks. The pre-commit hook auto-formats staged Rust files and blocks
+Rust/Cargo commits unless `cargo clippy --workspace --all-targets -- -D warnings`
+passes.
+
 Integration tests under `specs/*.yml` hit real Roblox endpoints. They're opt-in and gated by environment variables; CI runs them in a separate workflow against a dedicated test account.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ lithos deploy --environment dev
 ## What it does
 
 - **Plans before it touches anything.** `deploy` shows a preview of every create / update / delete it's about to perform, with field-level summaries for risky resources (a price change on a developer product, a name change on a game pass) and explicit warnings on destructive operations. You can approve or cancel before a single byte hits Roblox.
+- **Runs preflight checks before apply.** Lithos catches common Roblox deploy failures early: missing Open Cloud keys, wrong universe scopes, unsupported target-access combinations, and place files that are close to Roblox's upload limits.
 - **Verifies live state.** Before applying, Lithos checks the persisted state against the actual Roblox API. If something was deleted manually in the dashboard, Lithos notices and re-creates it instead of failing on an update.
+- **Keeps rollback checkpoints.** Every deploy records the last known good graph plus a short apply journal so `lithos undo` can drive an environment back toward that snapshot if a deploy fails or turns out to be bad.
 - **Manages multi-place experiences.** Start places, side places, place files, configurations, thumbnails, icons — all of it.
 - **Handles the assets too.** Images, audio, badges, game passes, developer products, notifications, asset aliases, social links, spatial voice — the things that usually get forgotten on launch day.
 - **Stores state where you want it.** Locally next to your project, or remotely in S3 / Google Cloud Storage so a team or a CI runner can cooperate on the same experience.
@@ -60,7 +62,7 @@ The simplest path:
 ```toml
 # foreman.toml
 [tools]
-lithos = { source = "siriuslatte/lithos", version = "0.1.0" }
+lithos = { source = "siriuslatte/lithos", version = "0.2.0" }
 ```
 
 **Manual**
@@ -91,13 +93,14 @@ lithos deploy projects/getting-started --environment dev
 
 The first run creates an experience and a place; subsequent runs only push what changed. Run `lithos diff --environment dev` any time to see what would happen without actually deploying.
 
-If you're not signed into Roblox Studio on the same machine, set `ROBLOSECURITY` (and optionally `LITHOS_OPEN_CLOUD_API_KEY` for Open Cloud endpoints).
+If you're not signed into Roblox Studio on the same machine, set `ROBLOSECURITY` and, for Open Cloud-backed endpoints such as place publishing, `LITHOS_OPEN_CLOUD_API_KEY` (Lithos also accepts `ROBLOX_OPEN_CLOUD_API_KEY`).
 
 ## CLI
 
 ```
 lithos deploy        Apply your project's configuration to a Roblox environment
 lithos diff          Show what deploy would change
+lithos undo          Restore the last recorded good snapshot for an environment
 lithos destroy       Tear down everything Lithos created in an environment
 lithos outputs       Print resource IDs (place IDs, asset IDs, …) for use in your game
 lithos import        Adopt an existing experience into Lithos
@@ -114,6 +117,11 @@ lithos state         Manage local / remote state files
 
 In CI / piped contexts Lithos auto-approves after printing a plain summary, so
 existing scripts keep working without changes.
+
+If a deploy turns out to be bad, `lithos undo --environment <label>` uses the
+last checkpoint recorded for that environment. Undo is best-effort rather than
+transactional: Lithos imports live Roblox state, previews the diff back to the
+checkpoint, and then applies that rollback plan.
 
 ## Repository layout
 

--- a/docs/site/pages/docs/authentication.mdx
+++ b/docs/site/pages/docs/authentication.mdx
@@ -10,7 +10,7 @@ Lithos — they live in environment variables and `.env` files you control.
 | Credential | Used for | Required for |
 | --- | --- | --- |
 | `ROBLOSECURITY` | Legacy Roblox APIs (place uploads, configurations, social links, etc.) | Almost every deploy. |
-| `LITHOS_OPEN_CLOUD_API_KEY` | Roblox Open Cloud (asset uploads, place publish, etc.) | Most deploys; required for asset uploads. |
+| `LITHOS_OPEN_CLOUD_API_KEY` | Roblox Open Cloud (asset uploads, place publish, etc.) | Most deploys; required for asset uploads. `ROBLOX_OPEN_CLOUD_API_KEY` and `MANTLE_OPEN_CLOUD_API_KEY` are also accepted. |
 | `LITHOS_AWS_ACCESS_KEY_ID` / `LITHOS_AWS_SECRET_ACCESS_KEY` / `LITHOS_AWS_INHERIT_IAM_ROLE` | S3 / Cloudflare R2 remote state | Only when using [remote state](/docs/remote-state). |
 
 Lithos still honors the legacy `MANTLE_*` names. See
@@ -58,7 +58,7 @@ or new machines):
 3. Copy the value of the `.ROBLOSECURITY` cookie.
 4. In CI, store it as a secret named `ROBLOSECURITY`.
 
-## `LITHOS_OPEN_CLOUD_API_KEY`
+## `LITHOS_OPEN_CLOUD_API_KEY` (preferred)
 
 Roblox Open Cloud is the modern, scoped, server-to-server API. You will
 want a key for almost every project:
@@ -71,14 +71,21 @@ want a key for almost every project:
    - `asset:read`, `asset:write` — for uploading image and audio assets.
 5. Optionally restrict the key by IP. CI runners often have stable
    egress IPs you can pin.
-6. Set the key:
+6. Set the key.
 
-   ```shell filename=".env"
-   LITHOS_OPEN_CLOUD_API_KEY="…"
-   ```
+Example `.env` entry:
 
-Lithos prints a clear error naming the missing scope when an API call
-fails for a permissions reason — read it carefully before regenerating.
+```shell filename=".env"
+LITHOS_OPEN_CLOUD_API_KEY="…"
+```
+
+Lithos also accepts `ROBLOX_OPEN_CLOUD_API_KEY` and the legacy
+`MANTLE_OPEN_CLOUD_API_KEY`, but `LITHOS_OPEN_CLOUD_API_KEY` is the
+preferred name for docs and CI.
+
+Deploy preflight now introspects this key before apply when possible. If the
+key is missing, lacks `universe-places.write`, or is scoped to the wrong
+universe, Lithos stops early and prints the likely cause plus next steps.
 
 ## AWS credentials (only for remote state)
 

--- a/docs/site/pages/docs/commands.mdx
+++ b/docs/site/pages/docs/commands.mdx
@@ -2,14 +2,15 @@ import { Callout } from 'nextra-theme-docs';
 
 # CLI reference
 
-Every Lithos workflow is one of five subcommands. This page is the working
-reference; for the full machine-readable surface, run
-`lithos help [SUBCOMMAND]`.
+Every Lithos workflow is one of six subcommands. This page is the working
+reference; for the full machine-readable surface, run `lithos --help` or
+`lithos <subcommand> --help`.
 
 | Command | Purpose |
 | --- | --- |
 | [`deploy`](#deploy) | Reconcile state with config and apply the diff. |
 | [`diff`](#diff) | Print the diff without applying it. |
+| [`undo`](#undo) | Restore the last recorded checkpoint for an environment. |
 | [`outputs`](#outputs) | Print the outputs (asset IDs, etc.) of the last deploy. |
 | [`destroy`](#destroy) | Remove every resource Lithos manages for an environment. |
 | [`import`](#import) | Adopt an existing experience into a Lithos project. |
@@ -29,8 +30,9 @@ $ lithos deploy [PROJECT] --environment <label> [flags]
 The default workflow. `deploy` runs the pipeline described in
 **[The resource graph](/docs/concepts/resource-graph#how-a-deploy-unfolds)**:
 load config and state, reconcile state against the live Roblox API, build
-the desired graph, render a plan preview, prompt for confirmation, and
-apply the diff in dependency order.
+the desired graph, run preflight diagnostics, render a plan preview, prompt
+for confirmation, checkpoint the current environment state, and apply the diff
+in dependency order.
 
 ### Live reconciliation
 
@@ -64,6 +66,19 @@ When stdout is an interactive terminal, deploy prompts to confirm before
 applying. Press `y` or Enter to apply; anything else cancels. In
 non-interactive contexts (CI, piped output) deploy auto-approves after
 printing a plain summary, so existing scripts continue to work.
+
+### Preflight diagnostics and checkpoints
+
+Before approval, `deploy` runs a preflight pass over the plan and auth
+context. This catches the common Roblox failures that are otherwise vague at
+runtime: missing Open Cloud keys, missing `universe-places.write`, API keys
+that do not cover the target universe, unsupported group/public/friends
+combinations, and place files that are close to Roblox's size limits.
+
+If any preflight diagnostic is blocking, deploy stops before mutating
+anything. If preflight passes, Lithos records a checkpoint of the last known
+good graph so `lithos undo` can roll the environment back toward that
+snapshot later.
 
 ### Useful flags
 
@@ -100,6 +115,31 @@ $ lithos diff --environment dev --live
 
 Use `--live` when you suspect drift; use plain `diff` when you just want
 to know what your YAML changes would do.
+
+## `undo`
+
+```text
+$ lithos undo [PROJECT] --environment <label> [flags]
+```
+
+Best-effort rollback to the most recent checkpoint Lithos recorded for an
+environment. `undo` does not read old YAML or Git history. Instead it:
+
+1. Loads the baseline snapshot stored before the last deploy or undo.
+2. Imports the live Roblox experience so rollback plans against reality,
+   not stale state.
+3. Runs the same preflight diagnostics and plan preview as `deploy`.
+4. Applies the diff back toward that snapshot and records the result.
+
+Use the same preview flags as `deploy`: `--yes`, `--no-preview`, and
+`--plain-preview`. `--allow-purchases` is also supported in case rollback
+needs to recreate a paid resource.
+
+<Callout type="info">
+  Roblox deploys are not transactional. `undo` is therefore best-effort:
+  it reconciles live state and then drives resources back toward the last
+  checkpoint Lithos recorded.
+</Callout>
 
 ## `outputs`
 
@@ -177,7 +217,7 @@ then point `import` at production.
 | Code | Meaning |
 | --- | --- |
 | `0` | Success. Includes the case "nothing to do." |
-| `1` | A user-facing error. Bad config, auth failure, conflicting state, etc. The error message names the cause. |
-| `2` | An unexpected internal error. [File an issue](https://github.com/siriuslatte/lithos/issues) with the surrounding output. |
+| `1` | A user-facing failure. Bad config, auth failure, apply failure, conflicting state, etc. The error message names the cause. |
+| `2` | The command was cancelled at the preview / confirmation step. |
 
 In CI, treat any non-zero exit as fatal.

--- a/docs/site/pages/docs/concepts/resource-graph.mdx
+++ b/docs/site/pages/docs/concepts/resource-graph.mdx
@@ -84,6 +84,13 @@ Steps 1–4 are read-only (green). Nothing on Roblox changes until you
 confirm at step 5 (amber). This is what makes destructive mistakes
 recoverable: you always see them coming.
 
+<Callout type="info">
+  The diagram is intentionally simplified. Current `deploy` runs a preflight
+  diagnostics pass before confirmation, writes a rollback checkpoint before
+  apply, and saves both the new `current` graph and deployment journal to
+  state afterward.
+</Callout>
+
 ## Operation kinds
 
 Each node in the diff is exactly one of these:

--- a/docs/site/pages/docs/concepts/state.mdx
+++ b/docs/site/pages/docs/concepts/state.mdx
@@ -9,35 +9,52 @@ predictable diff.
 
 ## What is in the state file
 
-A YAML document keyed by environment, then by resource ID. For each
-resource, Lithos stores the inputs it deployed with and the outputs Roblox
-returned. Concretely:
+A versioned YAML document keyed by environment. In the current v7 format,
+each environment stores two things:
+
+- `current` — the resource graph from the latest successful deploy or undo.
+- `deployments` — a short history of checkpoints, results, and journals used
+  for recovery and `lithos undo`.
+
+Concretely:
 
 ```yaml filename=".lithos-state.yml"
+version: 7
 environments:
   dev:
-    experience_singleton:
-      inputs:
-        experience:
-          groupId: ~
-      outputs:
-        experience:
-          assetId: 3296599132
-          startPlaceId: 8667346609
-    place_start:
-      inputs: ~
-      outputs:
-        place:
-          assetId: 8667346609
-    placeFile_start:
-      inputs:
-        placeFile:
-          filePath: game.rbxlx
-          fileHash: 0c3a…
-      outputs:
-        placeFile:
-          version: 2
-    # … etc
+    current:
+      - id: experience_singleton
+        inputs:
+          experience:
+            groupId: ~
+        outputs:
+          experience:
+            assetId: 3296599132
+            startPlaceId: 8667346609
+      - id: placeFile_start
+        inputs:
+          placeFile:
+            filePath: game.rbxlx
+            fileHash: 0c3a…
+        outputs:
+          placeFile:
+            version: 2
+    deployments:
+      - id: deploy-1736370930123
+        kind: deploy
+        status: succeeded
+        startedAt: 2026-01-08T01:15:30Z
+        finishedAt: 2026-01-08T01:15:42Z
+        baseline: []
+        desired:
+          - id: experience_singleton
+        resulting:
+          - id: experience_singleton
+        journal:
+          - resourceId: experience_singleton
+            action: create
+            status: applied
+            summary: Applied create for experience_singleton
 ```
 
 You will rarely edit this by hand. The two things you should know:
@@ -48,11 +65,14 @@ You will rarely edit this by hand. The two things you should know:
 - **`outputs.assetId` is the canonical link between a Lithos resource and
   a real Roblox asset.** Lose it and the next deploy will re-create the
   asset from scratch.
+- **`deployments` is the recovery trail.** It records the last few deploys and
+  undos, including the baseline snapshot and a short journal of what changed.
+  `lithos undo` uses that history rather than guessing from Git.
 
 ## Where the state file lives
 
 Two options. They produce identical state; only the storage backend
-differs.
+differs. Both include the same current graph and rollback history.
 
 ### Local (the default)
 
@@ -119,7 +139,8 @@ for parallel writers.
 
 **Q: Can I delete the state file and start over?**
 Yes, but Lithos will think nothing exists and try to re-create every
-resource. The old assets stay on Roblox, orphaned. Better: use
+resource. The old assets stay on Roblox, orphaned, and you lose the rollback
+checkpoints recorded in `deployments`. Better: use
 `lithos import` to attach an existing experience to a fresh state file
 (experimental).
 

--- a/docs/site/pages/docs/continuous-deployment.mdx
+++ b/docs/site/pages/docs/continuous-deployment.mdx
@@ -10,8 +10,9 @@ CircleCI, Jenkins, etc.
 Two things make this setup robust:
 
 1. **Remote state.** With state in S3 or R2, every CI run sees the same
-   previous-state, regardless of which runner picked it up. Without remote
-   state, two runners can race and produce divergent state files.
+  previous-state, deployment checkpoints, and rollback history regardless of
+  which runner picked it up. Without remote state, two runners can race and
+  produce divergent state files.
 2. **Branch-gated environments.** A `prod` environment that only deploys
    from `main` cannot be deployed by a pull request, no matter how the
    workflow file is written.
@@ -98,6 +99,9 @@ A few details worth understanding:
 - **`--plain-preview`** drops ANSI color codes from the plan preview so
   GitHub's log viewer renders them legibly. Lithos auto-approves when
   stdout is not a TTY, so no `--yes` flag is needed.
+- **Preflight diagnostics run before apply** even in CI. Missing Open Cloud
+  scopes, wrong universe access, and other known deploy blockers fail the job
+  before any mutation is attempted.
 - **The branch → environment mapping in the script** is a belt-and-suspenders
   measure on top of the `branches:` constraint in `lithos.yml`. Either
   alone would prevent a `develop` push from touching `prod`, but both is
@@ -105,6 +109,11 @@ A few details worth understanding:
 - **Foreman pins the Lithos version** via `foreman.toml`. This is important:
   CI should not silently pick up a new Lithos release the day it's
   published.
+
+If a deploy finishes in a bad state, run `lithos undo --environment <label>
+--plain-preview` against the same remote state backend. Because the state file
+contains recent checkpoints, rollback can be initiated from a runner or an
+operator workstation without reconstructing an older YAML revision first.
 
 ## Pull-request previews
 

--- a/docs/site/pages/docs/getting-started.mdx
+++ b/docs/site/pages/docs/getting-started.mdx
@@ -75,7 +75,8 @@ The version you get is whatever `examples/foreman.toml` pins.
 The example deploys to a real Roblox account, so Lithos needs two things:
 
 - A `ROBLOSECURITY` cookie (used for the legacy site APIs).
-- A `LITHOS_OPEN_CLOUD_API_KEY` (used for everything Open Cloud supports).
+- A `LITHOS_OPEN_CLOUD_API_KEY` (used for everything Open Cloud supports;
+  `ROBLOX_OPEN_CLOUD_API_KEY` is also accepted).
 
 The **[Authentication page](/docs/authentication)** has the full story.
 The shortest version:
@@ -86,12 +87,14 @@ The shortest version:
 2. If you are signed in to Roblox Studio on this machine, Lithos will pick
    up your `ROBLOSECURITY` automatically. If not, set it explicitly.
 3. Put both in a `.env` file at the project root (next to `examples/`),
-   and add `.env` to `.gitignore`:
+  and add `.env` to `.gitignore`.
 
-   ```shell filename=".env"
-   LITHOS_OPEN_CLOUD_API_KEY="…"
-   ROBLOSECURITY="…"
-   ```
+Example `.env`:
+
+```shell filename=".env"
+LITHOS_OPEN_CLOUD_API_KEY="…"
+ROBLOSECURITY="…"
+```
 
 ## 3. Deploy
 
@@ -101,9 +104,10 @@ From `examples/`:
 $ lithos deploy projects/getting-started --environment dev
 ```
 
-Lithos prints three sections: **Loading project**, **Deploying resources**,
-and **Saving state**, followed by a summary of where the new experience
-lives on Roblox.
+Lithos prints several sections: **Loading project**,
+**Running preflight checks**, **Checkpointing deployment state**,
+**Deploying resources**, and **Saving state**, followed by a summary of where
+the new experience lives on Roblox.
 
 ```text filename="lithos deploy"
 Loading project:
@@ -148,6 +152,10 @@ Deploying resources:
 The summary line is the part you want to scan in CI logs:
 `6 create(s)`, `0 delete(s)` means six resources were created and nothing
 was destroyed.
+
+If preflight finds a blocking issue first — a missing Open Cloud key, wrong
+universe scope, or an unsupported target-access setting — Lithos stops before
+mutating anything and prints the likely cause plus next steps.
 
 Finally:
 
@@ -198,7 +206,21 @@ That is the entire pitch for infrastructure-as-code in one CLI run: you
 edited one line of YAML, and Lithos did the minimum amount of work
 required to make Roblox match it.
 
-## 5. (Optional) clean up
+Lithos also saved a rollback checkpoint before applying those changes. If the
+next deploy ever goes bad, you do not need to reconstruct old YAML first.
+
+## 5. Undo a bad deploy
+
+```text
+$ lithos undo projects/getting-started --environment dev
+```
+
+`undo` imports the live experience, loads the last checkpoint Lithos recorded
+for that environment, previews the diff back to that checkpoint, and then
+applies it. This is best-effort rather than transactional, but it is much
+faster than manually rebuilding state after a bad push.
+
+## 6. (Optional) clean up
 
 If you do not want the example experience hanging around your account:
 

--- a/docs/site/pages/docs/guides/migrating-from-mantle.mdx
+++ b/docs/site/pages/docs/guides/migrating-from-mantle.mdx
@@ -20,7 +20,7 @@ changes and the recommended order in which to adopt them.
 | `mantle.yml` | `lithos.yml` | Both are read; `lithos.yml` wins. |
 | `.mantle-state.yml` | `.lithos-state.yml` | Both are read; `lithos`-named wins. New writes always go to the Lithos name. |
 | `<key>.mantle-state.yml` (S3/R2) | `<key>.lithos-state.yml` | Same fallback for remote keys. |
-| `MANTLE_OPEN_CLOUD_API_KEY` | `LITHOS_OPEN_CLOUD_API_KEY` | Both honored; `LITHOS_*` wins. |
+| `MANTLE_OPEN_CLOUD_API_KEY` | `LITHOS_OPEN_CLOUD_API_KEY` | Both honored; `LITHOS_*` wins. `ROBLOX_OPEN_CLOUD_API_KEY` is also accepted. |
 | `MANTLE_AWS_ACCESS_KEY_ID` | `LITHOS_AWS_ACCESS_KEY_ID` | Both honored; `LITHOS_*` wins. |
 | `MANTLE_AWS_SECRET_ACCESS_KEY` | `LITHOS_AWS_SECRET_ACCESS_KEY` | Both honored; `LITHOS_*` wins. |
 | `MANTLE_AWS_INHERIT_IAM_ROLE` | `LITHOS_AWS_INHERIT_IAM_ROLE` | Both honored. |
@@ -40,6 +40,9 @@ fixes; some are new capabilities.
   developer products, game passes, badges, notifications, experiences, and
   places are flagged explicitly. Cancel before confirmation and nothing
   happens. See **[CLI reference](/docs/commands#deploy)**.
+- **Preflight diagnostics and rollback checkpoints.** Lithos validates the
+  common Roblox failure modes before apply, stores the previous environment
+  graph as a checkpoint, and provides `lithos undo` for best-effort recovery.
 - **`lithos diff --live`.** Run the same reconciliation pass that `deploy`
   runs, but only print the diff — useful for "what would happen if I
   deployed right now?" without prompting or writing.
@@ -64,7 +67,7 @@ Update `foreman.toml`:
 ```toml filename="foreman.toml"
 [tools]
 - mantle = { source = "blake-mealey/mantle", version = "0.11" }
-+ lithos = { source = "siriuslatte/lithos", version = "0.1" }
++ lithos = { source = "siriuslatte/lithos", version = "0.2.0" }
 ```
 
 Run `foreman install`. Update any scripts or CI commands that invoke
@@ -90,7 +93,9 @@ when both are present; renaming silences the legacy-file warning.
 
 In your CI secrets, in your `.env` files, and in your team docs, replace
 the `MANTLE_*` variables with `LITHOS_*`. Both work, but `LITHOS_*` is
-preferred and `MANTLE_*` will be removed in a future release.
+preferred and `MANTLE_*` will be removed in a future release. Lithos also
+accepts `ROBLOX_OPEN_CLOUD_API_KEY`, but `LITHOS_OPEN_CLOUD_API_KEY` is the
+recommended project-facing name.
 
 ```diff filename=".env"
 - MANTLE_OPEN_CLOUD_API_KEY="…"
@@ -111,7 +116,8 @@ your bucket.
 <Callout type="warning">
   Do not delete the legacy state file before running at least one
   successful Lithos deploy. The legacy file is your rollback path while
-  you verify the migration.
+  you verify the migration. After that first Lithos deploy, the new
+  `.lithos-state.yml` will also contain Lithos-managed rollback checkpoints.
 </Callout>
 
 ## What does **not** change

--- a/docs/site/pages/docs/intro.mdx
+++ b/docs/site/pages/docs/intro.mdx
@@ -15,8 +15,8 @@ you need to use Lithos productively.
 
 1. **A configuration file** (`lithos.yml`) — the source of truth. What you
    want to exist.
-2. **A state file** (`.lithos-state.yml`, local or remote) — what actually
-   exists, as far as Lithos last knew.
+2. **A state file** (`.lithos-state.yml`, local or remote) — the current
+  graph Lithos believes exists, plus a short deployment history.
 3. **A live API** (Roblox + Open Cloud) — what actually exists *right now*.
 
 Every command is a function of those three inputs. `deploy` reconciles them
@@ -28,6 +28,11 @@ plan a diff, apply it, write new state.
   thinks exists; the live API is what really exists.** When they disagree,
   Lithos calls that *drift*, and reconciles it before doing anything
   destructive.
+</Callout>
+
+<Callout type="info">
+  Lithos also stores recent deployment checkpoints in state. That history is
+  what powers `lithos undo`.
 </Callout>
 
 ## What "infrastructure-as-code" buys you
@@ -42,7 +47,9 @@ The practical consequence:
 
 - Every deploy is **reviewable**: a plan preview shows exactly which fields
   on which resources will change, before any byte hits Roblox.
-- Every change is **rollback-able**: revert the YAML, redeploy.
+- Every change is **rollback-able**: revert the YAML and redeploy when you are
+  intentionally changing desired state, or run `lithos undo` to drive Roblox
+  back to the last recorded checkpoint.
 - Every environment is **reproducible**: `dev` and `prod` come from the same
   config with declarative overrides, not parallel checklists.
 - Every CI pipeline is **boring**: a single binary, a state file in S3 or
@@ -77,8 +84,8 @@ $ lithos deploy
 
 That creates a Roblox experience, uploads `game.rbxlx` as its start place,
 sets the place name and genre, and writes a state file recording the
-resulting asset IDs. Re-run the command and Lithos does nothing — state
-matches config, nothing to do.
+resulting asset IDs plus the deployment checkpoint. Re-run the command and
+Lithos does nothing — state matches config, nothing to do.
 
 Change the place name in the YAML and re-run, and Lithos updates exactly
 that one field, in place, with no other side effects.

--- a/docs/site/pages/docs/remote-state.mdx
+++ b/docs/site/pages/docs/remote-state.mdx
@@ -1,5 +1,4 @@
 ﻿import { Card, Cards } from 'nextra/components';
-import { Database } from 'react-feather';
 
 # Remote State
 
@@ -13,6 +12,11 @@ which comes with a few benefits.
 Since a remote state file can be accessed and updated from anywhere, you can share it across
 branches and computers. This makes it less likely your state files gets out of sync with the real
 resources in Roblox, and it is ideal for continuous deployment (CD) scenarios.
+
+Remote state now carries more than the latest resource graph. It also stores a
+short deployment history per environment, including rollback checkpoints and
+apply journals. That means a CI runner and a local operator looking at the
+same remote object also see the same recovery history for `lithos undo`.
 
 ### Supported cloud providers
 

--- a/docs/site/pages/index.mdx
+++ b/docs/site/pages/index.mdx
@@ -1,7 +1,7 @@
 ﻿import Link from 'next/link';
 
 <div className="relative w-full px-6 pt-20 pb-10 sm:pt-28 sm:pb-14 flex flex-col gap-7 items-center justify-center text-center">
-  <span className="lithos-pill">Roblox Infrastructure-as-Code · v0.1</span>
+  <span className="lithos-pill">Roblox Infrastructure-as-Code · v0.2.0</span>
 
   <h1 className="text-6xl sm:text-7xl md:text-8xl font-extrabold tracking-tight leading-none">
     <span className="lithos-gradient-text">Lithos</span>

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,11 +24,14 @@ lithos deploy projects/getting-started --environment dev
 # 4. Preview future changes without applying them.
 lithos diff projects/getting-started --environment dev
 
-# 5. Tear it down when you're done.
+# 5. Roll back to the last checkpoint if a deploy goes bad.
+lithos undo projects/getting-started --environment dev
+
+# 6. Tear it down when you're done.
 lithos destroy projects/getting-started --environment dev
 ```
 
-If you're not signed into Roblox Studio on the same machine, set the `ROBLOSECURITY` environment variable. Set `LITHOS_OPEN_CLOUD_API_KEY` if you want to use Open Cloud endpoints (e.g. notifications).
+If you're not signed into Roblox Studio on the same machine, set the `ROBLOSECURITY` environment variable. Set `LITHOS_OPEN_CLOUD_API_KEY` if you want to use Open Cloud endpoints such as place publishing and notifications. Lithos also accepts `ROBLOX_OPEN_CLOUD_API_KEY`.
 
 ## Tinkering
 
@@ -37,6 +40,7 @@ The fastest way to learn Lithos is to edit a `lithos.yml`, run `lithos diff --en
 - Bump a developer product's `price` and see the field-level diff.
 - Add a third badge.
 - Toggle `targetAccess` on the dev environment between `private` and `friends`.
+- Break a deploy on purpose, then inspect the preflight diagnostics and use `lithos undo --environment dev` to roll back.
 - Move the state file to S3 by uncommenting the `state.remote` block.
 
 Existing Mantle projects keep working — Lithos reads `mantle.yml` and `.mantle-state.yml` as fallbacks. See the top-level

--- a/examples/foreman.toml
+++ b/examples/foreman.toml
@@ -1,4 +1,4 @@
 [tools]
 # `lithos` is the CLI binary. Releases are published from
 # https://github.com/siriuslatte/lithos/releases.
-lithos = { source = "siriuslatte/lithos", version = "0.1" }
+lithos = { source = "siriuslatte/lithos", version = "0.2.0" }

--- a/lithos/Cargo.toml
+++ b/lithos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lithos"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Infra-as-code and deployment tool for Roblox (formerly Mantle)"
 license = "MIT"

--- a/lithos/src/cli.rs
+++ b/lithos/src/cli.rs
@@ -109,6 +109,39 @@ fn get_app() -> App<'static, 'static> {
                         .takes_value(true))
         )
         .subcommand(
+            SubCommand::with_name("undo")
+                .about("Best-effort rollback to the last known good snapshot for a Lithos environment.")
+                .arg(
+                    Arg::with_name("PROJECT")
+                        .index(1)
+                        .help(PROJECT_HELP)
+                        .takes_value(true))
+                .arg(
+                    Arg::with_name("environment")
+                        .long("environment")
+                        .short("e")
+                        .help("The label of the environment to roll back. If not specified, attempts to match the current git branch to each environment's `branches` property.")
+                        .value_name("ENVIRONMENT")
+                        .takes_value(true))
+                .arg(
+                    Arg::with_name("allow_purchases")
+                        .long("allow-purchases")
+                        .help("Gives Lithos permission to make purchases with Robux if restoring the last known good state requires re-creating paid resources."))
+                .arg(
+                    Arg::with_name("yes")
+                        .long("yes")
+                        .short("y")
+                        .help("Skip the interactive plan confirmation prompt and apply immediately. In non-interactive (CI/piped) environments undo already auto-approves; this flag silences the auto-approve notice."))
+                .arg(
+                    Arg::with_name("no_preview")
+                        .long("no-preview")
+                        .help("Skip the rollback plan preview entirely. Implies --yes."))
+                .arg(
+                    Arg::with_name("plain_preview")
+                        .long("plain-preview")
+                        .help("Show a plain-text rollback summary instead of the rich color-coded preview. Useful for CI logs."))
+        )
+        .subcommand(
             SubCommand::with_name("outputs")
                 .about("Prints a Lithos environment's outputs to the console or a file in a machine-readable format.")
                 .arg(
@@ -252,6 +285,27 @@ pub async fn run_with(args: Vec<String>) -> i32 {
             commands::destroy::run(
                 destroy_matches.value_of("PROJECT"),
                 destroy_matches.value_of("environment"),
+            )
+            .await
+        }
+        ("undo", Some(undo_matches)) => {
+            let no_preview = undo_matches.is_present("no_preview");
+            let plain_preview = undo_matches.is_present("plain_preview");
+            let preview_options = PreviewOptions {
+                mode: if no_preview {
+                    PreviewMode::Off
+                } else if plain_preview {
+                    PreviewMode::Plain
+                } else {
+                    PreviewMode::Auto
+                },
+                assume_yes: undo_matches.is_present("yes") || no_preview,
+            };
+            commands::undo::run(
+                undo_matches.value_of("PROJECT"),
+                undo_matches.value_of("environment"),
+                undo_matches.is_present("allow_purchases"),
+                preview_options,
             )
             .await
         }

--- a/lithos/src/commands/deploy.rs
+++ b/lithos/src/commands/deploy.rs
@@ -4,17 +4,20 @@ use yansi::Paint;
 
 use rbx_lithos::{
     config::{load_project_config, TargetConfig},
+    diagnostics::{run_preflight_checks, DiagnosticReport, PreflightAuthContext},
     project::{load_project, Project},
     resource_graph::{EvaluateResults, ResourceGraph},
     roblox_resource_manager::{RobloxInputs, RobloxOutputs, RobloxResource, RobloxResourceManager},
+    state::v7::{DeploymentKind, DeploymentStatus},
     state::{
-        get_desired_graph, reconcile_graph, save_state, ReconciliationReport,
-        RobloxLiveStateVerifier, VerificationStatus,
+        build_failure_journal, build_success_journal, get_desired_graph, reconcile_graph,
+        save_state, DeploymentProgressWriter, ReconciliationReport, RobloxLiveStateVerifier,
+        VerificationStatus,
     },
 };
 
 use crate::preview::{
-    model::Plan,
+    model::{Plan, RollbackSummary},
     render::{preview_and_confirm, Decision, PreviewOptions},
 };
 use crate::tui::progress::Spinner;
@@ -129,6 +132,78 @@ fn log_target_results(
     logger::end_action_without_message();
 }
 
+fn log_preflight_report(report: &DiagnosticReport) {
+    logger::start_action("Running preflight checks:");
+
+    if report.blocking.is_empty() && report.warnings.is_empty() {
+        logger::end_action("Succeeded");
+        return;
+    }
+
+    for diagnostic in &report.blocking {
+        logger::log(format!("{} {}", Paint::red("!"), diagnostic.summary));
+        if let Some(detail) = &diagnostic.detail {
+            logger::log(format!("    {}", detail));
+        }
+        for next_step in &diagnostic.next_steps {
+            logger::log(format!("    next: {}", next_step));
+        }
+    }
+
+    for diagnostic in &report.warnings {
+        logger::log(format!("{} {}", Paint::yellow("?"), diagnostic.summary));
+        if let Some(detail) = &diagnostic.detail {
+            logger::log(format!("    {}", detail));
+        }
+    }
+
+    if report.has_blocking() {
+        logger::end_action(Paint::red(format!(
+            "Blocked with {} error(s) and {} warning(s)",
+            report.blocking.len(),
+            report.warnings.len()
+        )));
+    } else {
+        logger::end_action(format!(
+            "Succeeded with {} warning(s)",
+            report.warnings.len()
+        ));
+    }
+}
+
+fn rollback_readiness_summary(
+    state_config: &rbx_lithos::config::StateConfig,
+    current_graph: &ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs>,
+) -> RollbackSummary {
+    let backend = match state_config {
+        rbx_lithos::config::StateConfig::Local => "local state file".to_owned(),
+        rbx_lithos::config::StateConfig::LocalKey(key) => {
+            format!("local keyed state file ({})", key)
+        }
+        rbx_lithos::config::StateConfig::Remote(config) => format!("remote state ({})", config),
+    };
+
+    let mut details = vec![format!(
+        "Lithos will checkpoint the current environment in {} before apply starts.",
+        backend
+    )];
+    if current_graph.get_resource_list().is_empty() {
+        details.push(
+            "This environment has no prior managed resources, so undo will restore the environment back to an empty managed state if this deploy fails or needs to be reverted.".to_owned(),
+        );
+    } else {
+        details.push(
+            "Undo will use the last known good snapshot plus live import to plan a best-effort rollback after failure or a bad deploy.".to_owned(),
+        );
+    }
+
+    RollbackSummary {
+        ready: true,
+        summary: "A last-known-good checkpoint will be captured before apply.".to_owned(),
+        details,
+    }
+}
+
 pub async fn run(
     project: Option<&str>,
     environment: Option<&str>,
@@ -183,6 +258,28 @@ pub async fn run(
     };
 
     // Live reconciliation: verify persisted state against the Roblox platform
+    let open_cloud_key = resource_manager
+        .introspect_open_cloud_api_key()
+        .await
+        .ok()
+        .flatten();
+    let preflight_report = run_preflight_checks(
+        project_path.as_path(),
+        &target_config,
+        &owner_config,
+        &current_graph,
+        &next_graph,
+        &PreflightAuthContext {
+            open_cloud_api_key_present: resource_manager.has_open_cloud_api_key(),
+            open_cloud_key,
+        },
+    );
+    log_preflight_report(&preflight_report);
+    if preflight_report.has_blocking() {
+        logger::end_action(Paint::red("Apply aborted by preflight diagnostics"));
+        return 1;
+    }
+
     // before evaluating the graph. This catches out-of-band deletions and
     // ensures we do not attempt to update or delete assets that no longer
     // exist. Resources whose status is `Verified`, `Skipped`, or `Unknown`
@@ -221,6 +318,7 @@ pub async fn run(
     // Pre-apply preview. We derive the plan from the same graphs that
     // `evaluate` is about to act on, so what the user sees and what deploy
     // does cannot drift apart. Confirmation gates any destructive action.
+    let rollback_summary = rollback_readiness_summary(&state_config, &current_graph);
     {
         let diff = match next_graph.diff(&current_graph) {
             Ok(d) => d,
@@ -234,6 +332,8 @@ pub async fn run(
             &current_graph,
             &next_graph,
             Some(&reconciliation_report),
+            Some(&preflight_report),
+            Some(rollback_summary.clone()),
         );
 
         match preview_and_confirm(&plan, preview_options) {
@@ -245,9 +345,40 @@ pub async fn run(
         }
     }
 
-    let results = next_graph
-        .evaluate(&current_graph, &mut resource_manager, allow_purchases)
-        .await;
+    logger::start_action("Checkpointing last known good state:");
+    let deployment_id = state.begin_deployment(
+        &environment_config.label,
+        DeploymentKind::Deploy,
+        current_graph.get_resource_list(),
+        next_graph.get_resource_list(),
+        None,
+    );
+    match save_state(&project_path, &state_config, &state).await {
+        Ok(_) => logger::end_action("Succeeded"),
+        Err(e) => {
+            logger::end_action(Paint::red(e));
+            return 1;
+        }
+    };
+
+    let results = {
+        let mut progress_writer = DeploymentProgressWriter::new(
+            project_path.as_path(),
+            &state_config,
+            &mut state,
+            &environment_config.label,
+            &deployment_id,
+            &current_graph,
+        );
+        next_graph
+            .evaluate_with_progress(
+                &current_graph,
+                &mut resource_manager,
+                allow_purchases,
+                Some(&mut progress_writer),
+            )
+            .await
+    };
     match &results {
         Ok(results) => {
             match results {
@@ -272,8 +403,57 @@ pub async fn run(
         }
         Err(e) => {
             logger::end_action(Paint::red(e));
+            if e.applied_mutation_count() > 0 {
+                logger::log(Paint::yellow(format!(
+                    "Deployment failed after {} applied mutation(s). The environment may be partially updated.",
+                    e.applied_mutation_count()
+                )));
+            }
+            logger::log(format!(
+                "Recovery: run {} to drive the environment back toward the last known good snapshot.",
+                Paint::cyan(format!(
+                    "lithos undo --environment {}",
+                    environment_config.label
+                ))
+            ));
         }
     };
+
+    let journal = match &results {
+        Ok(_) => build_success_journal(&current_graph, &next_graph),
+        Err(error) => build_failure_journal(&current_graph, &next_graph, error),
+    };
+
+    let deployment_summary = match &results {
+        Ok(EvaluateResults {
+            created_count,
+            updated_count,
+            deleted_count,
+            noop_count,
+            skipped_count,
+        }) => Some(format!(
+            "Applied {} create(s), {} update(s), {} delete(s), {} noop(s), {} skip(s)",
+            created_count, updated_count, deleted_count, noop_count, skipped_count
+        )),
+        Err(error) => Some(format!(
+            "Failed after {} applied mutation(s) and {} recorded failure(s)",
+            error.applied_mutation_count(),
+            error.failure_count()
+        )),
+    };
+
+    state.complete_deployment(
+        &environment_config.label,
+        &deployment_id,
+        if results.is_ok() {
+            DeploymentStatus::Succeeded
+        } else {
+            DeploymentStatus::Failed
+        },
+        next_graph.get_resource_list(),
+        journal,
+        deployment_summary,
+    );
 
     if environment_config.tag_commit && results.is_ok() {
         logger::start_action("Tagging commit:");
@@ -292,10 +472,6 @@ pub async fn run(
     }
 
     logger::start_action("Saving state:");
-    state.environments.insert(
-        environment_config.label.clone(),
-        next_graph.get_resource_list(),
-    );
     match save_state(&project_path, &state_config, &state).await {
         Ok(_) => {}
         Err(e) => {

--- a/lithos/src/commands/destroy.rs
+++ b/lithos/src/commands/destroy.rs
@@ -72,12 +72,13 @@ pub async fn run(project: Option<&str>, environment: Option<&str>) -> i32 {
     logger::start_action("Saving state:");
     let resource_list = next_graph.get_resource_list();
     if resource_list.is_empty() {
-        state.environments.remove(&environment_config.label);
+        state
+            .ensure_environment_mut(&environment_config.label)
+            .current = Vec::new();
     } else {
-        state.environments.insert(
-            environment_config.label.clone(),
-            next_graph.get_resource_list(),
-        );
+        state
+            .ensure_environment_mut(&environment_config.label)
+            .current = next_graph.get_resource_list();
     }
     match save_state(&project_path, &state_config, &state).await {
         Ok(_) => {}

--- a/lithos/src/commands/diff.rs
+++ b/lithos/src/commands/diff.rs
@@ -95,14 +95,14 @@ pub async fn run(
             return 1;
         }
     };
-    let mut next_graph =
-        match get_desired_graph(project_path.as_path(), &target_config, &owner_config) {
-            Ok(v) => v,
-            Err(e) => {
-                logger::end_action(Paint::red(e));
-                return 1;
-            }
-        };
+    let next_graph = match get_desired_graph(project_path.as_path(), &target_config, &owner_config)
+    {
+        Ok(v) => v,
+        Err(e) => {
+            logger::end_action(Paint::red(e));
+            return 1;
+        }
+    };
     logger::end_action("Succeeded");
 
     // Optional live reconciliation. Off by default to keep `diff` fast and
@@ -172,7 +172,7 @@ pub async fn run(
                 && std::io::stdin().is_terminal();
 
             if interactive {
-                let plan = Plan::build(&diff, &current_graph, &next_graph, None);
+                let plan = Plan::build(&diff, &current_graph, &next_graph, None, None, None);
                 // `diff` is read-only so we surface the viewer in `Off`-style
                 // semantics: the decision is ignored, we just want the user
                 // to see and explore the plan.

--- a/lithos/src/commands/import.rs
+++ b/lithos/src/commands/import.rs
@@ -1,4 +1,4 @@
-﻿use std::sync::Arc;
+use std::sync::Arc;
 
 use rbx_api::{models::AssetId, RobloxApi};
 use rbx_auth::{RobloxCookieStore, RobloxCsrfTokenStore};
@@ -89,10 +89,9 @@ pub async fn run(project: Option<&str>, environment: Option<&str>, target_id: &s
     logger::end_action("Succeeded");
 
     logger::start_action("Saving state:");
-    state.environments.insert(
-        environment_config.label.clone(),
-        imported_graph.get_resource_list(),
-    );
+    state
+        .ensure_environment_mut(&environment_config.label)
+        .current = imported_graph.get_resource_list();
     match save_state(&project_path, &state_config, &state).await {
         Ok(_) => {}
         Err(e) => {

--- a/lithos/src/commands/mod.rs
+++ b/lithos/src/commands/mod.rs
@@ -4,4 +4,5 @@ pub mod diff;
 pub mod download;
 pub mod import;
 pub mod outputs;
+pub mod undo;
 pub mod upload;

--- a/lithos/src/commands/undo.rs
+++ b/lithos/src/commands/undo.rs
@@ -1,0 +1,341 @@
+use yansi::Paint;
+
+use rbx_lithos::{
+    config::load_project_config,
+    diagnostics::{run_preflight_checks, DiagnosticReport, PreflightAuthContext},
+    project::{load_project, Project},
+    resource_graph::{EvaluateResults, Resource, ResourceGraph},
+    roblox_resource_manager::{RobloxOutputs, RobloxResource, RobloxResourceManager},
+    state::{
+        build_failure_journal, build_success_journal, import_graph, save_state,
+        v7::{DeploymentKind, DeploymentStatus},
+        DeploymentProgressWriter,
+    },
+};
+
+use crate::preview::{
+    model::{Plan, RollbackSummary},
+    render::{preview_and_confirm, Decision, PreviewOptions},
+};
+
+fn log_preflight_report(report: &DiagnosticReport) {
+    logger::start_action("Running rollback preflight checks:");
+
+    if report.blocking.is_empty() && report.warnings.is_empty() {
+        logger::end_action("Succeeded");
+        return;
+    }
+
+    for diagnostic in &report.blocking {
+        logger::log(format!("{} {}", Paint::red("!"), diagnostic.summary));
+        if let Some(detail) = &diagnostic.detail {
+            logger::log(format!("    {}", detail));
+        }
+        for next_step in &diagnostic.next_steps {
+            logger::log(format!("    next: {}", next_step));
+        }
+    }
+
+    for diagnostic in &report.warnings {
+        logger::log(format!("{} {}", Paint::yellow("?"), diagnostic.summary));
+        if let Some(detail) = &diagnostic.detail {
+            logger::log(format!("    {}", detail));
+        }
+    }
+
+    if report.has_blocking() {
+        logger::end_action(Paint::red(format!(
+            "Blocked with {} error(s) and {} warning(s)",
+            report.blocking.len(),
+            report.warnings.len()
+        )));
+    } else {
+        logger::end_action(format!(
+            "Succeeded with {} warning(s)",
+            report.warnings.len()
+        ));
+    }
+}
+
+fn extract_experience_id(resources: &[RobloxResource]) -> Option<u64> {
+    resources
+        .iter()
+        .find_map(|resource| match resource.get_outputs() {
+            Some(RobloxOutputs::Experience(outputs)) => Some(outputs.asset_id),
+            _ => None,
+        })
+}
+
+fn rollback_plan_summary(record: &rbx_lithos::state::v7::DeploymentRecord) -> RollbackSummary {
+    let details = vec![
+        format!("Rolling back to the snapshot captured at {}.", record.started_at),
+        format!(
+            "The most recent deployment record is currently marked {}.",
+            match record.status {
+                DeploymentStatus::InProgress => "in progress",
+                DeploymentStatus::Succeeded => "succeeded",
+                DeploymentStatus::Failed => "failed",
+            }
+        ),
+        "Undo is best-effort: Roblox deploys are not transactional, so Lithos will reconcile live state and then drive resources back toward this snapshot.".to_owned(),
+    ];
+
+    RollbackSummary {
+        ready: true,
+        summary: "Lithos will restore the last known good checkpoint for this environment."
+            .to_owned(),
+        details,
+    }
+}
+
+pub async fn run(
+    project: Option<&str>,
+    environment: Option<&str>,
+    allow_purchases: bool,
+    preview_options: PreviewOptions,
+) -> i32 {
+    logger::start_action("Loading project:");
+    let (project_path, config) = match load_project_config(project) {
+        Ok(v) => v,
+        Err(e) => {
+            logger::end_action(Paint::red(e));
+            return 1;
+        }
+    };
+    let Project {
+        current_graph,
+        mut state,
+        environment_config,
+        target_config,
+        payment_source,
+        state_config,
+        owner_config,
+    } = match load_project(project_path.clone(), config, environment).await {
+        Ok(Some(v)) => v,
+        Ok(None) => {
+            logger::end_action("No rollback target available");
+            return 0;
+        }
+        Err(e) => {
+            logger::end_action(Paint::red(e));
+            return 1;
+        }
+    };
+
+    let Some(rollback_record) = state
+        .latest_rollback_record(&environment_config.label)
+        .cloned()
+    else {
+        logger::end_action(Paint::red(
+            "No rollback snapshot is recorded for this environment yet.",
+        ));
+        return 1;
+    };
+    let rollback_resources = rollback_record.baseline.clone();
+    logger::end_action("Succeeded");
+
+    logger::start_action("Loading live environment:");
+    let mut resource_manager = match RobloxResourceManager::new(&project_path, payment_source).await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            logger::end_action(Paint::red(e));
+            return 1;
+        }
+    };
+
+    let import_target_id = extract_experience_id(&rollback_record.resulting)
+        .or_else(|| extract_experience_id(&rollback_resources))
+        .or_else(|| match current_graph.get_outputs("experience_singleton") {
+            Some(RobloxOutputs::Experience(outputs)) => Some(outputs.asset_id),
+            _ => None,
+        });
+
+    let live_graph = match import_target_id {
+        Some(target_id) => match import_graph(resource_manager.api(), target_id).await {
+            Ok(graph) => {
+                logger::end_action("Succeeded");
+                graph
+            }
+            Err(e) => {
+                logger::end_action(Paint::red(e));
+                return 1;
+            }
+        },
+        None => {
+            logger::end_action("No live experience found; assuming an empty managed state");
+            ResourceGraph::new(&Vec::new())
+        }
+    };
+
+    let mut rollback_graph = ResourceGraph::new(&rollback_resources);
+    let open_cloud_key = resource_manager
+        .introspect_open_cloud_api_key()
+        .await
+        .ok()
+        .flatten();
+    let preflight_report = run_preflight_checks(
+        project_path.as_path(),
+        &target_config,
+        &owner_config,
+        &live_graph,
+        &rollback_graph,
+        &PreflightAuthContext {
+            open_cloud_api_key_present: resource_manager.has_open_cloud_api_key(),
+            open_cloud_key,
+        },
+    );
+    log_preflight_report(&preflight_report);
+    if preflight_report.has_blocking() {
+        return 1;
+    }
+
+    let diff = match rollback_graph.diff(&live_graph) {
+        Ok(diff) => diff,
+        Err(e) => {
+            logger::log(Paint::red(format!(
+                "Failed to compute rollback plan diff: {}",
+                e
+            )));
+            return 1;
+        }
+    };
+    let plan = Plan::build(
+        &diff,
+        &live_graph,
+        &rollback_graph,
+        None,
+        Some(&preflight_report),
+        Some(rollback_plan_summary(&rollback_record)),
+    );
+
+    match preview_and_confirm(&plan, preview_options) {
+        Decision::Approve => {}
+        Decision::Cancel => {
+            logger::log(Paint::yellow("Undo cancelled by user."));
+            return 2;
+        }
+    }
+
+    logger::start_action("Checkpointing pre-undo state:");
+    let deployment_id = state.begin_deployment(
+        &environment_config.label,
+        DeploymentKind::Undo,
+        current_graph.get_resource_list(),
+        rollback_graph.get_resource_list(),
+        None,
+    );
+    match save_state(&project_path, &state_config, &state).await {
+        Ok(_) => logger::end_action("Succeeded"),
+        Err(e) => {
+            logger::end_action(Paint::red(e));
+            return 1;
+        }
+    };
+
+    logger::start_action("Undoing resources:");
+    let results = {
+        let mut progress_writer = DeploymentProgressWriter::new(
+            project_path.as_path(),
+            &state_config,
+            &mut state,
+            &environment_config.label,
+            &deployment_id,
+            &live_graph,
+        );
+        rollback_graph
+            .evaluate_with_progress(
+                &live_graph,
+                &mut resource_manager,
+                allow_purchases,
+                Some(&mut progress_writer),
+            )
+            .await
+    };
+    match &results {
+        Ok(results) => match results {
+            EvaluateResults {
+                created_count: 0,
+                updated_count: 0,
+                deleted_count: 0,
+                skipped_count: 0,
+                ..
+            } => logger::end_action("No changes required"),
+            EvaluateResults {
+                created_count,
+                updated_count,
+                deleted_count,
+                noop_count,
+                skipped_count,
+            } => logger::end_action(format!(
+                "Succeeded with {} create(s), {} update(s), {} delete(s), {} noop(s), {} skip(s)",
+                created_count, updated_count, deleted_count, noop_count, skipped_count
+            )),
+        },
+        Err(error) => {
+            logger::end_action(Paint::red(error));
+            if error.applied_mutation_count() > 0 {
+                logger::log(Paint::yellow(format!(
+                    "Undo failed after {} applied mutation(s). The environment may still be partially updated.",
+                    error.applied_mutation_count()
+                )));
+            }
+            logger::log(format!(
+                "Recovery: inspect the rollback journal in state and rerun {} after correcting the issue.",
+                Paint::cyan(format!(
+                    "lithos undo --environment {}",
+                    environment_config.label
+                ))
+            ));
+        }
+    }
+
+    let journal = match &results {
+        Ok(_) => build_success_journal(&live_graph, &rollback_graph),
+        Err(error) => build_failure_journal(&live_graph, &rollback_graph, error),
+    };
+    let summary = match &results {
+        Ok(EvaluateResults {
+            created_count,
+            updated_count,
+            deleted_count,
+            noop_count,
+            skipped_count,
+        }) => Some(format!(
+            "Undo applied {} create(s), {} update(s), {} delete(s), {} noop(s), {} skip(s)",
+            created_count, updated_count, deleted_count, noop_count, skipped_count
+        )),
+        Err(error) => Some(format!(
+            "Undo failed after {} applied mutation(s) and {} recorded failure(s)",
+            error.applied_mutation_count(),
+            error.failure_count()
+        )),
+    };
+
+    state.complete_deployment(
+        &environment_config.label,
+        &deployment_id,
+        if results.is_ok() {
+            DeploymentStatus::Succeeded
+        } else {
+            DeploymentStatus::Failed
+        },
+        rollback_graph.get_resource_list(),
+        journal,
+        summary,
+    );
+
+    logger::start_action("Saving state:");
+    match save_state(&project_path, &state_config, &state).await {
+        Ok(_) => logger::end_action("Succeeded"),
+        Err(e) => {
+            logger::end_action(Paint::red(e));
+            return 1;
+        }
+    };
+
+    match results {
+        Ok(_) => 0,
+        Err(_) => 1,
+    }
+}

--- a/lithos/src/preview/model.rs
+++ b/lithos/src/preview/model.rs
@@ -7,6 +7,7 @@
 use std::collections::BTreeMap;
 
 use rbx_lithos::{
+    diagnostics::DiagnosticReport,
     resource_graph::{Resource, ResourceGraph, ResourceGraphDiff},
     roblox_resource_manager::{RobloxInputs, RobloxOutputs, RobloxResource},
     state::{ReconciliationReport, VerificationStatus},
@@ -123,6 +124,15 @@ impl PlanCounts {
 pub struct Plan {
     pub rows: Vec<PlanRow>,
     pub counts: PlanCounts,
+    pub preflight: DiagnosticReport,
+    pub rollback: Option<RollbackSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RollbackSummary {
+    pub ready: bool,
+    pub summary: String,
+    pub details: Vec<String>,
 }
 
 impl Plan {
@@ -134,6 +144,8 @@ impl Plan {
         previous_graph: &ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs>,
         next_graph: &ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs>,
         reconciliation: Option<&ReconciliationReport>,
+        preflight: Option<&DiagnosticReport>,
+        rollback: Option<RollbackSummary>,
     ) -> Self {
         let prev_inputs = collect_inputs(previous_graph);
         let next_inputs = collect_inputs(next_graph);
@@ -259,7 +271,12 @@ impl Plan {
             }
         }
 
-        Plan { rows, counts }
+        Plan {
+            rows,
+            counts,
+            preflight: preflight.cloned().unwrap_or_default(),
+            rollback,
+        }
     }
 
     #[allow(dead_code)]

--- a/lithos/src/preview/render.rs
+++ b/lithos/src/preview/render.rs
@@ -168,6 +168,9 @@ fn interactive_flow(plan: &Plan) -> Decision {
 fn render_rich(plan: &Plan) {
     let mut body: Vec<String> = Vec::new();
     body.push(format_header(plan));
+
+    append_diagnostic_summary(plan, &mut body, true);
+    append_rollback_summary(plan, &mut body, true);
     body.push(String::new());
 
     if plan.rows.is_empty() {
@@ -225,6 +228,8 @@ fn render_plain(plan: &Plan) {
     eprintln!();
     eprintln!("Lithos plan");
     eprintln!("{}", strip_color(&format_header(plan)));
+    render_plain_diagnostic_summary(plan);
+    render_plain_rollback_summary(plan);
     eprintln!();
     if plan.rows.is_empty() {
         eprintln!("  No changes. Your infrastructure is up to date.");
@@ -251,15 +256,153 @@ fn render_plain(plan: &Plan) {
 
 fn format_header(plan: &Plan) -> String {
     let c = &plan.counts;
+    let preflight_summary = if plan.preflight.has_blocking() || !plan.preflight.warnings.is_empty()
+    {
+        format!(
+            "   {} preflight!   {} preflight?",
+            Paint::red(format!("!{}", plan.preflight.blocking.len())).bold(),
+            Paint::yellow(format!("?{}", plan.preflight.warnings.len())).bold(),
+        )
+    } else {
+        String::new()
+    };
     format!(
-        "{} create   {} update   {} delete   {} dep   {} drift!   {} drift?",
+        "{} create   {} update   {} delete   {} dep   {} drift!   {} drift?{}",
         Paint::green(format!("+{}", c.creates)).bold(),
         Paint::yellow(format!("~{}", c.updates)).bold(),
         Paint::red(format!("-{}", c.deletes)).bold(),
         Paint::new(format!("○{}", c.dependency_changes)).dimmed(),
         Paint::red(format!("!{}", c.drift_recreate)).bold(),
         Paint::yellow(format!("?{}", c.drift_unknown)),
+        preflight_summary,
     )
+}
+
+fn append_diagnostic_summary(plan: &Plan, body: &mut Vec<String>, rich: bool) {
+    if plan.preflight.blocking.is_empty() && plan.preflight.warnings.is_empty() {
+        return;
+    }
+
+    body.push(if rich {
+        format!("{}", Paint::new("Preflight").bold())
+    } else {
+        "Preflight".to_owned()
+    });
+
+    for diagnostic in &plan.preflight.blocking {
+        body.push(format!(
+            "  {} {}",
+            if rich {
+                format!("{}", Paint::red("!").bold())
+            } else {
+                "!".to_owned()
+            },
+            diagnostic.summary
+        ));
+        if let Some(detail) = &diagnostic.detail {
+            body.push(format!(
+                "      {}",
+                if rich {
+                    format!("{}", Paint::new(detail).dimmed())
+                } else {
+                    detail.clone()
+                }
+            ));
+        }
+    }
+
+    for diagnostic in &plan.preflight.warnings {
+        body.push(format!(
+            "  {} {}",
+            if rich {
+                format!("{}", Paint::yellow("?").bold())
+            } else {
+                "?".to_owned()
+            },
+            diagnostic.summary
+        ));
+        if let Some(detail) = &diagnostic.detail {
+            body.push(format!(
+                "      {}",
+                if rich {
+                    format!("{}", Paint::new(detail).dimmed())
+                } else {
+                    detail.clone()
+                }
+            ));
+        }
+    }
+}
+
+fn append_rollback_summary(plan: &Plan, body: &mut Vec<String>, rich: bool) {
+    let Some(rollback) = plan.rollback.as_ref() else {
+        return;
+    };
+
+    body.push(if rich {
+        format!("{}", Paint::new("Rollback").bold())
+    } else {
+        "Rollback".to_owned()
+    });
+
+    let marker = if rollback.ready {
+        if rich {
+            format!("{}", Paint::green("+").bold())
+        } else {
+            "+".to_owned()
+        }
+    } else if rich {
+        format!("{}", Paint::yellow("?").bold())
+    } else {
+        "?".to_owned()
+    };
+    body.push(format!("  {} {}", marker, rollback.summary));
+    for detail in &rollback.details {
+        body.push(format!(
+            "      {}",
+            if rich {
+                format!("{}", Paint::new(detail).dimmed())
+            } else {
+                detail.clone()
+            }
+        ));
+    }
+}
+
+fn render_plain_diagnostic_summary(plan: &Plan) {
+    if plan.preflight.blocking.is_empty() && plan.preflight.warnings.is_empty() {
+        return;
+    }
+
+    eprintln!("Preflight");
+    for diagnostic in &plan.preflight.blocking {
+        eprintln!("  ! {}", diagnostic.summary);
+        if let Some(detail) = &diagnostic.detail {
+            eprintln!("      {}", detail);
+        }
+    }
+    for diagnostic in &plan.preflight.warnings {
+        eprintln!("  ? {}", diagnostic.summary);
+        if let Some(detail) = &diagnostic.detail {
+            eprintln!("      {}", detail);
+        }
+    }
+}
+
+fn render_plain_rollback_summary(plan: &Plan) {
+    let Some(rollback) = plan.rollback.as_ref() else {
+        return;
+    };
+
+    eprintln!("Rollback");
+    eprintln!(
+        "  {} {}",
+        if rollback.ready { "+" } else { "?" },
+        rollback.summary
+    );
+    for detail in &rollback.details {
+        eprintln!("      {}", detail);
+    }
 }
 
 fn colorize_marker(kind: ActionKind) -> Paint<&'static str> {
@@ -352,6 +495,8 @@ mod tests {
                 creates: 1,
                 ..Default::default()
             },
+            preflight: Default::default(),
+            rollback: None,
         }
     }
 

--- a/lithos/src/tui/plan_view.rs
+++ b/lithos/src/tui/plan_view.rs
@@ -157,12 +157,20 @@ fn event_loop(terminal: &mut Term, plan: &Plan) -> io::Result<Decision> {
 }
 
 fn draw(frame: &mut Frame, plan: &Plan, state: &mut ViewState) {
+    let header_height = if plan.preflight.has_blocking()
+        || !plan.preflight.warnings.is_empty()
+        || plan.rollback.is_some()
+    {
+        5
+    } else {
+        3
+    };
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3), // header
-            Constraint::Min(5),    // body
-            Constraint::Length(3), // footer / hints
+            Constraint::Length(header_height), // header
+            Constraint::Min(5),                // body
+            Constraint::Length(3),             // footer / hints
         ])
         .split(frame.area());
 
@@ -173,7 +181,7 @@ fn draw(frame: &mut Frame, plan: &Plan, state: &mut ViewState) {
 
 fn draw_header(frame: &mut Frame, plan: &Plan, area: Rect) {
     let c = &plan.counts;
-    let line = Line::from(vec![
+    let mut lines = vec![Line::from(vec![
         Span::styled(
             format!("+{} ", c.creates),
             Style::default()
@@ -202,9 +210,42 @@ fn draw_header(frame: &mut Frame, plan: &Plan, area: Rect) {
             format!("?{}", c.drift_unknown),
             Style::default().fg(Color::Yellow),
         ),
-    ]);
+    ])];
 
-    let header = Paragraph::new(line).block(
+    if plan.preflight.has_blocking() || !plan.preflight.warnings.is_empty() {
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("preflight !{} ", plan.preflight.blocking.len()),
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("?{}", plan.preflight.warnings.len()),
+                Style::default().fg(Color::Yellow),
+            ),
+        ]));
+    }
+
+    if let Some(rollback) = plan.rollback.as_ref() {
+        lines.push(Line::from(vec![
+            Span::styled(
+                if rollback.ready {
+                    "rollback ready: "
+                } else {
+                    "rollback note: "
+                },
+                Style::default()
+                    .fg(if rollback.ready {
+                        Color::Green
+                    } else {
+                        Color::Yellow
+                    })
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(rollback.summary.clone()),
+        ]));
+    }
+
+    let header = Paragraph::new(lines).block(
         Block::default()
             .borders(Borders::ALL)
             .title(Span::styled(

--- a/rbx_api/src/api_keys/mod.rs
+++ b/rbx_api/src/api_keys/mod.rs
@@ -1,0 +1,27 @@
+pub mod models;
+
+use serde_json::json;
+
+use crate::{errors::RobloxApiResult, helpers::get_roblox_api_error_from_response, RobloxApi};
+
+use self::models::IntrospectApiKeyResponse;
+
+impl RobloxApi {
+    pub async fn introspect_api_key(
+        &self,
+        api_key: &str,
+    ) -> RobloxApiResult<IntrospectApiKeyResponse> {
+        let response = self
+            .client
+            .post("https://apis.roblox.com/api-keys/v1/introspect")
+            .json(&json!({ "apiKey": api_key }))
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            Ok(response.json::<IntrospectApiKeyResponse>().await?)
+        } else {
+            Err(get_roblox_api_error_from_response(response).await)
+        }
+    }
+}

--- a/rbx_api/src/api_keys/models.rs
+++ b/rbx_api/src/api_keys/models.rs
@@ -1,0 +1,69 @@
+use serde::Deserialize;
+
+use crate::models::AssetId;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IntrospectApiKeyResponse {
+    pub name: String,
+    pub authorized_user_id: Option<AssetId>,
+    #[serde(default)]
+    pub scopes: Vec<ApiKeyScope>,
+    pub enabled: bool,
+    pub expired: bool,
+    pub expiration_time_utc: Option<String>,
+}
+
+impl IntrospectApiKeyResponse {
+    pub fn has_scope_operation(&self, scope_name: &str, operation: &str) -> bool {
+        self.scopes
+            .iter()
+            .any(|scope| scope.matches(scope_name, operation))
+    }
+
+    pub fn allows_universe_operation(
+        &self,
+        scope_name: &str,
+        operation: &str,
+        universe_id: AssetId,
+    ) -> bool {
+        self.scopes.iter().any(|scope| {
+            scope.matches(scope_name, operation)
+                && scope
+                    .universe_ids
+                    .iter()
+                    .any(|value| value == "*" || value == &universe_id.to_string())
+        })
+    }
+
+    pub fn has_wildcard_universe_operation(&self, scope_name: &str, operation: &str) -> bool {
+        self.scopes.iter().any(|scope| {
+            scope.matches(scope_name, operation)
+                && scope.universe_ids.iter().any(|value| value == "*")
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiKeyScope {
+    pub name: String,
+    #[serde(default)]
+    pub operations: Vec<String>,
+    #[serde(default)]
+    pub user_ids: Vec<String>,
+    #[serde(default)]
+    pub group_ids: Vec<String>,
+    #[serde(default)]
+    pub universe_ids: Vec<String>,
+}
+
+impl ApiKeyScope {
+    pub fn matches(&self, scope_name: &str, operation: &str) -> bool {
+        self.name == scope_name
+            && self
+                .operations
+                .iter()
+                .any(|value| value.eq_ignore_ascii_case(operation))
+    }
+}

--- a/rbx_api/src/lib.rs
+++ b/rbx_api/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod api_keys;
 pub mod asset_aliases;
 pub mod asset_permissions;
 pub mod assets;

--- a/rbx_lithos/Cargo.toml
+++ b/rbx_lithos/Cargo.toml
@@ -33,7 +33,7 @@ schemars = { version = "=0.8.8-blake.2", git = "https://github.com/blake-mealey/
     "preserve_order",
 ] }
 rbxcloud = "0.13.0"
+reqwest = "0.11"
 
 [dev-dependencies]
-reqwest = "0.11"
 tokio = { version = "1", features = ["full", "macros", "rt-multi-thread"] }

--- a/rbx_lithos/README.md
+++ b/rbx_lithos/README.md
@@ -17,5 +17,5 @@ is the entry point.
 - `resource_graph` — the typed resource DAG and its `ResourceManager` trait.
 - `roblox_resource_manager` — the Roblox-specific implementation of the graph
   (creates / updates / deletes via `rbx_api` and `rbxcloud`).
-- `state` — versioned state file format (v1–v6), reconciliation, and live
-  drift verification.
+- `state` — versioned state file format (v1–v7), reconciliation, deployment
+  history, rollback helpers, and live drift verification.

--- a/rbx_lithos/src/diagnostics.rs
+++ b/rbx_lithos/src/diagnostics.rs
@@ -1,0 +1,1340 @@
+use std::{error::Error, fmt, fs, path::Path};
+
+use rbx_api::{
+    api_keys::models::IntrospectApiKeyResponse, errors::RobloxApiError, models::AssetId,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    config::{OwnerConfig, PlayabilityTargetConfig, TargetConfig},
+    resource_graph::{Resource, ResourceGraph},
+    roblox_resource_manager::{RobloxInputs, RobloxOutputs, RobloxResource},
+};
+
+const ROBLOX_PLACE_SIZE_LIMIT_BYTES: u64 = 100 * 1024 * 1024;
+const ROBLOX_PLACE_WARNING_BYTES: u64 = 90 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum DiagnosticSeverity {
+    Error,
+    Warning,
+    Info,
+}
+
+impl OperationContext {
+    pub fn with_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = Some(endpoint.into());
+        self
+    }
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum DiagnosticCategory {
+    Preflight,
+    Authentication,
+    Authorization,
+    Ownership,
+    Configuration,
+    File,
+    Roblox,
+    Rollback,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum DiagnosticConfidence {
+    Confirmed,
+    High,
+    Medium,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum OperationAction {
+    Preflight,
+    Create,
+    Update,
+    Delete,
+    Rollback,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationContext {
+    pub action: OperationAction,
+    pub resource_id: Option<String>,
+    pub resource_type: String,
+    pub auth_model: String,
+    pub creator_target: Option<String>,
+    pub endpoint: Option<String>,
+    pub file_path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeploymentDiagnostic {
+    pub code: String,
+    pub severity: DiagnosticSeverity,
+    pub category: DiagnosticCategory,
+    pub confidence: DiagnosticConfidence,
+    pub summary: String,
+    pub detail: Option<String>,
+    #[serde(default)]
+    pub probable_causes: Vec<String>,
+    #[serde(default)]
+    pub next_steps: Vec<String>,
+    pub operation: Option<OperationContext>,
+}
+
+impl DeploymentDiagnostic {
+    pub fn error(code: &str, category: DiagnosticCategory, summary: impl Into<String>) -> Self {
+        Self {
+            code: code.to_owned(),
+            severity: DiagnosticSeverity::Error,
+            category,
+            confidence: DiagnosticConfidence::Confirmed,
+            summary: summary.into(),
+            detail: None,
+            probable_causes: Vec::new(),
+            next_steps: Vec::new(),
+            operation: None,
+        }
+    }
+
+    pub fn warning(code: &str, category: DiagnosticCategory, summary: impl Into<String>) -> Self {
+        Self {
+            code: code.to_owned(),
+            severity: DiagnosticSeverity::Warning,
+            category,
+            confidence: DiagnosticConfidence::Medium,
+            summary: summary.into(),
+            detail: None,
+            probable_causes: Vec::new(),
+            next_steps: Vec::new(),
+            operation: None,
+        }
+    }
+
+    pub fn with_confidence(mut self, confidence: DiagnosticConfidence) -> Self {
+        self.confidence = confidence;
+        self
+    }
+
+    pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+
+    pub fn with_probable_causes(mut self, probable_causes: Vec<String>) -> Self {
+        self.probable_causes = probable_causes;
+        self
+    }
+
+    pub fn with_next_steps(mut self, next_steps: Vec<String>) -> Self {
+        self.next_steps = next_steps;
+        self
+    }
+
+    pub fn with_operation(mut self, operation: OperationContext) -> Self {
+        self.operation = Some(operation);
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OperationError {
+    summary: String,
+    diagnostics: Vec<DeploymentDiagnostic>,
+}
+
+impl OperationError {
+    pub fn new(summary: impl Into<String>, diagnostics: Vec<DeploymentDiagnostic>) -> Self {
+        Self {
+            summary: summary.into(),
+            diagnostics,
+        }
+    }
+
+    pub fn from_diagnostic(diagnostic: DeploymentDiagnostic) -> Self {
+        let summary = diagnostic.summary.clone();
+        Self::new(summary, vec![diagnostic])
+    }
+
+    pub fn summary(&self) -> &str {
+        &self.summary
+    }
+
+    pub fn diagnostics(&self) -> &[DeploymentDiagnostic] {
+        &self.diagnostics
+    }
+}
+
+impl fmt::Display for OperationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.summary)
+    }
+}
+
+impl Error for OperationError {}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticReport {
+    #[serde(default)]
+    pub blocking: Vec<DeploymentDiagnostic>,
+    #[serde(default)]
+    pub warnings: Vec<DeploymentDiagnostic>,
+    #[serde(default)]
+    pub info: Vec<DeploymentDiagnostic>,
+}
+
+impl DiagnosticReport {
+    pub fn push(&mut self, diagnostic: DeploymentDiagnostic) {
+        match diagnostic.severity {
+            DiagnosticSeverity::Error => self.blocking.push(diagnostic),
+            DiagnosticSeverity::Warning => self.warnings.push(diagnostic),
+            DiagnosticSeverity::Info => self.info.push(diagnostic),
+        }
+    }
+
+    pub fn has_blocking(&self) -> bool {
+        !self.blocking.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PreflightAuthContext {
+    pub open_cloud_api_key_present: bool,
+    pub open_cloud_key: Option<IntrospectApiKeyResponse>,
+}
+
+pub fn run_preflight_checks(
+    project_path: &Path,
+    target_config: &TargetConfig,
+    owner_config: &OwnerConfig,
+    current_graph: &ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs>,
+    next_graph: &ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs>,
+    auth: &PreflightAuthContext,
+) -> DiagnosticReport {
+    let mut report = DiagnosticReport::default();
+
+    validate_target_configuration(target_config, owner_config, &mut report);
+
+    let existing_experience_id = match current_graph.get_outputs("experience_singleton") {
+        Some(RobloxOutputs::Experience(outputs)) => Some(outputs.asset_id),
+        _ => None,
+    };
+
+    let mut requires_open_cloud_place_publish = false;
+
+    for resource in next_graph.get_resource_list() {
+        let resource_id = resource.get_id();
+        match resource.get_inputs() {
+            RobloxInputs::PlaceFile(file) => {
+                requires_open_cloud_place_publish = true;
+                validate_place_file(project_path, &resource_id, &file.file_path, &mut report);
+            }
+            RobloxInputs::ExperienceIcon(file)
+            | RobloxInputs::ExperienceThumbnail(file)
+            | RobloxInputs::ProductIcon(file)
+            | RobloxInputs::BadgeIcon(file) => {
+                validate_file_extension(
+                    project_path,
+                    &resource_id,
+                    &file.file_path,
+                    &["png", "jpg", "jpeg", "bmp", "gif", "tga"],
+                    "image",
+                    &mut report,
+                );
+            }
+            RobloxInputs::Pass(file) => {
+                validate_file_extension(
+                    project_path,
+                    &resource_id,
+                    &file.icon_file_path,
+                    &["png", "jpg", "jpeg", "bmp", "gif", "tga"],
+                    "image",
+                    &mut report,
+                );
+            }
+            RobloxInputs::Badge(file) => {
+                validate_file_extension(
+                    project_path,
+                    &resource_id,
+                    &file.icon_file_path,
+                    &["png", "jpg", "jpeg", "bmp", "gif", "tga"],
+                    "image",
+                    &mut report,
+                );
+            }
+            RobloxInputs::ImageAsset(file) => {
+                validate_file_extension(
+                    project_path,
+                    &resource_id,
+                    &file.file_path,
+                    &["png", "jpg", "jpeg", "bmp", "gif", "tga"],
+                    "image",
+                    &mut report,
+                );
+            }
+            RobloxInputs::AudioAsset(file) => {
+                validate_file_extension(
+                    project_path,
+                    &resource_id,
+                    &file.file_path,
+                    &["ogg", "mp3"],
+                    "audio",
+                    &mut report,
+                );
+            }
+            _ => {}
+        }
+    }
+
+    if requires_open_cloud_place_publish {
+        validate_place_publish_auth(existing_experience_id, auth, &mut report);
+    }
+
+    report
+}
+
+pub fn map_roblox_api_error(context: OperationContext, error: &RobloxApiError) -> OperationError {
+    match error {
+        RobloxApiError::Authorization => OperationError::from_diagnostic(
+            DeploymentDiagnostic::error(
+                "roblosecurity-authorization-denied",
+                DiagnosticCategory::Authentication,
+                format!(
+                    "Roblox denied the authenticated session while trying to {} {}.",
+                    action_label(context.action),
+                    context.resource_type
+                ),
+            )
+            .with_confidence(DiagnosticConfidence::High)
+            .with_detail(format!(
+                "The request was redirected to Roblox login instead of completing{}.{}",
+                context
+                    .endpoint
+                    .as_ref()
+                    .map(|endpoint| format!(" via {}", endpoint))
+                    .unwrap_or_default(),
+                context_detail_suffix(&context),
+            ))
+            .with_next_steps(vec![
+                "Refresh the ROBLOSECURITY cookie used for authentication.".to_owned(),
+                "If this deploy should run headlessly, verify that the CI secret still contains a valid cookie and that the account still has access to the target creator.".to_owned(),
+            ])
+            .with_operation(context),
+        ),
+        RobloxApiError::Roblox {
+            status_code,
+            reason,
+        } => classify_roblox_response(context, *status_code, reason),
+        RobloxApiError::InvalidFileExtension(path) => OperationError::from_diagnostic(
+            DeploymentDiagnostic::error(
+                "invalid-file-extension",
+                DiagnosticCategory::File,
+                format!("Roblox rejected an unsupported file extension for {}.", path),
+            )
+            .with_detail(format!(
+                "Lithos attempted to {} {}, but the file extension is not supported.{}",
+                action_label(context.action),
+                context.resource_type,
+                context_detail_suffix(&context),
+            ))
+            .with_next_steps(vec![
+                "Use one of Roblox's supported file formats for this resource type.".to_owned(),
+                "Re-run `lithos deploy` after fixing the file path or extension.".to_owned(),
+            ])
+            .with_operation(context),
+        ),
+        RobloxApiError::NoFileName(path) => OperationError::from_diagnostic(
+            DeploymentDiagnostic::error(
+                "missing-file-name",
+                DiagnosticCategory::File,
+                format!("Roblox could not determine a file name for {}.", path),
+            )
+            .with_detail(format!(
+                "The path could not be converted into a valid Roblox upload file name.{}",
+                context_detail_suffix(&context),
+            ))
+            .with_next_steps(vec![
+                "Use a normal file path with a file name and extension.".to_owned(),
+            ])
+            .with_operation(context),
+        ),
+        RobloxApiError::ReadFile(error) => OperationError::from_diagnostic(
+            DeploymentDiagnostic::error(
+                "read-file-failed",
+                DiagnosticCategory::File,
+                format!("Lithos could not read a local file while preparing {}.", context.resource_type),
+            )
+            .with_detail(format!("{}{}", error, context_detail_suffix(&context)))
+            .with_next_steps(vec![
+                "Restore the referenced file and verify the process still has permission to read it.".to_owned(),
+            ])
+            .with_operation(context),
+        ),
+        RobloxApiError::RbxlxPlaceFileSizeTooLarge
+        | RobloxApiError::RbxlPlaceFileSizeTooLarge
+        | RobloxApiError::RbxlxPlaceFileSizeMayBeTooLarge
+        | RobloxApiError::RbxlPlaceFileSizeMayBeTooLarge => map_operation_message(context, &error.to_string()),
+        RobloxApiError::Other(error) => map_operation_message(context, &error.to_string()),
+        other => OperationError::from_diagnostic(
+            DeploymentDiagnostic::error(
+                "roblox-request-failed",
+                DiagnosticCategory::Roblox,
+                format!(
+                    "Roblox failed while trying to {} {}.",
+                    action_label(context.action),
+                    context.resource_type
+                ),
+            )
+            .with_confidence(DiagnosticConfidence::High)
+            .with_detail(format!("{}{}", other, context_detail_suffix(&context)))
+            .with_next_steps(vec![
+                "Retry the deploy after verifying authentication and creator permissions.".to_owned(),
+            ])
+            .with_operation(context),
+        ),
+    }
+}
+
+pub fn map_operation_message(context: OperationContext, message: &str) -> OperationError {
+    let lower = message.to_ascii_lowercase();
+
+    if lower.contains("open cloud authentication") {
+        return OperationError::from_diagnostic(
+            DeploymentDiagnostic::error(
+                "missing-open-cloud-authentication",
+                DiagnosticCategory::Authentication,
+                "Place publishing requires an Open Cloud API key.".to_owned(),
+            )
+            .with_detail(format!("{}{}", message, context_detail_suffix(&context)))
+            .with_next_steps(vec![
+                "Create or rotate a Roblox API key with `universe-places.write`.".to_owned(),
+                "Set `LITHOS_OPEN_CLOUD_API_KEY` before rerunning deploy. Lithos also accepts `ROBLOX_OPEN_CLOUD_API_KEY`.".to_owned(),
+            ])
+            .with_operation(context),
+        );
+    }
+
+    if lower.contains("quota") && context.resource_type == "AudioAsset" {
+        return OperationError::from_diagnostic(
+            DeploymentDiagnostic::error(
+                "audio-upload-quota-exhausted",
+                DiagnosticCategory::Roblox,
+                "Roblox audio upload quota is exhausted for the current period.",
+            )
+            .with_detail(format!("{}{}", message, context_detail_suffix(&context)))
+            .with_next_steps(vec![
+                "Wait for the Roblox audio quota window to reset or use a different creator account with available quota.".to_owned(),
+            ])
+            .with_operation(context),
+        );
+    }
+
+    if context.resource_type == "PlaceFile"
+        && (lower.contains("403")
+            || lower.contains("401")
+            || lower.contains("forbidden")
+            || lower.contains("permission"))
+    {
+        return OperationError::from_diagnostic(place_publish_permission_diagnostic(
+            context,
+            Some(message.to_owned()),
+            DiagnosticConfidence::High,
+        ));
+    }
+
+    if context.resource_type == "PlaceFile"
+        && (lower.contains("internal server error")
+            || lower.contains("unknown error")
+            || lower.contains("500"))
+    {
+        return OperationError::from_diagnostic(place_publish_vague_server_diagnostic(
+            context,
+            Some(message.to_owned()),
+        ));
+    }
+
+    OperationError::from_diagnostic(
+        DeploymentDiagnostic::error(
+            "operation-failed",
+            DiagnosticCategory::Roblox,
+            format!(
+                "{} {} failed.",
+                action_label(context.action).to_uppercase_first(),
+                context.resource_type
+            ),
+        )
+        .with_confidence(DiagnosticConfidence::High)
+        .with_detail(format!("{}{}", message, context_detail_suffix(&context)))
+        .with_next_steps(vec![
+            "Review the resource-specific error details above and retry the deploy after correcting the underlying Roblox-side issue.".to_owned(),
+        ])
+        .with_operation(context),
+    )
+}
+
+fn classify_roblox_response(
+    context: OperationContext,
+    status_code: reqwest::StatusCode,
+    reason: &str,
+) -> OperationError {
+    let status = status_code.as_u16();
+    let lower_reason = reason.to_ascii_lowercase();
+
+    if context.resource_type == "PlaceFile"
+        && (status == 401 || status == 403 || lower_reason.contains("permission"))
+    {
+        return OperationError::from_diagnostic(place_publish_permission_diagnostic(
+            context,
+            Some(format!("{}: {}", status_code, reason)),
+            DiagnosticConfidence::Confirmed,
+        ));
+    }
+
+    if context.resource_type == "PlaceFile"
+        && (status >= 500
+            || lower_reason.contains("internal server error")
+            || lower_reason.contains("unknown error"))
+    {
+        return OperationError::from_diagnostic(place_publish_vague_server_diagnostic(
+            context,
+            Some(format!("{}: {}", status_code, reason)),
+        ));
+    }
+
+    if context.resource_type == "Experience"
+        && context.action == OperationAction::Create
+        && status >= 500
+        && context
+            .creator_target
+            .as_deref()
+            .map(|value| value.starts_with("group:"))
+            .unwrap_or(false)
+    {
+        return OperationError::from_diagnostic(
+            DeploymentDiagnostic::error(
+                "group-experience-create-vague-failure",
+                DiagnosticCategory::Roblox,
+                "Roblox returned a vague server failure while creating a group-owned experience.",
+            )
+            .with_confidence(DiagnosticConfidence::High)
+            .with_detail(format!(
+                "{}: {}{}",
+                status_code,
+                reason,
+                context_detail_suffix(&context),
+            ))
+            .with_probable_causes(vec![
+                "The authenticated account is missing the group permission required to create or edit group experiences.".to_owned(),
+                "Roblox is blocking the operation behind a group-specific prerequisite, such as role permissions or legal/terms acceptance, but only surfaced a generic server error.".to_owned(),
+            ])
+            .with_next_steps(vec![
+                "Verify that the account can manually create or edit the target group's experiences in Creator Dashboard or Studio.".to_owned(),
+                "If this is new group automation, confirm the group has accepted any required Roblox legal terms and that the automation account has the correct group role.".to_owned(),
+            ])
+            .with_operation(context),
+        );
+    }
+
+    let category = if status == 401 || status == 403 {
+        DiagnosticCategory::Authorization
+    } else {
+        DiagnosticCategory::Roblox
+    };
+    let confidence = if status >= 500 || lower_reason.contains("unknown error") {
+        DiagnosticConfidence::High
+    } else {
+        DiagnosticConfidence::Confirmed
+    };
+
+    OperationError::from_diagnostic(
+        DeploymentDiagnostic::error(
+            "roblox-response-failed",
+            category,
+            format!(
+                "Roblox returned {} while trying to {} {}.",
+                status_code,
+                action_label(context.action),
+                context.resource_type
+            ),
+        )
+        .with_confidence(confidence)
+        .with_detail(format!("{}{}", reason, context_detail_suffix(&context)))
+        .with_next_steps(vec![
+            "Check creator permissions, ownership, and resource configuration for this operation.".to_owned(),
+            "Retry once after correcting the issue. If the response stays vague, validate the same action manually in Creator Dashboard or Studio to identify any platform-side gating.".to_owned(),
+        ])
+        .with_operation(context),
+    )
+}
+
+fn place_publish_permission_diagnostic(
+    context: OperationContext,
+    detail: Option<String>,
+    confidence: DiagnosticConfidence,
+) -> DeploymentDiagnostic {
+    let detail = detail.unwrap_or_else(|| "Roblox denied the place publishing request.".to_owned());
+
+    DeploymentDiagnostic::error(
+        "place-publish-permission-denied",
+        DiagnosticCategory::Authorization,
+        "Roblox denied the place publishing request.",
+    )
+    .with_confidence(confidence)
+    .with_detail(format!("{}{}", detail, context_detail_suffix(&context)))
+    .with_probable_causes(vec![
+        "The Open Cloud API key is missing `universe-places.write` for the target experience.".to_owned(),
+        "The API key is restricted to a different experience or blocked by an IP allowlist.".to_owned(),
+        "The account behind the API key no longer has permission to publish to the target creator or group.".to_owned(),
+    ])
+    .with_next_steps(vec![
+        "Run Lithos preflight and confirm the key includes `universe-places.write` for this universe.".to_owned(),
+        "Verify the automation account can publish the same place manually or via Creator Dashboard/Studio.".to_owned(),
+    ])
+    .with_operation(context)
+}
+
+fn place_publish_vague_server_diagnostic(
+    context: OperationContext,
+    detail: Option<String>,
+) -> DeploymentDiagnostic {
+    let detail = detail.unwrap_or_else(|| {
+        "Roblox returned a vague server error while publishing the place.".to_owned()
+    });
+
+    DeploymentDiagnostic::error(
+        "place-publish-vague-server-error",
+        DiagnosticCategory::Roblox,
+        "Roblox returned a vague server error while publishing the place.",
+    )
+    .with_confidence(DiagnosticConfidence::High)
+    .with_detail(format!("{}{}", detail, context_detail_suffix(&context)))
+    .with_probable_causes(vec![
+        "The place publish request is failing behind a generic Roblox server response, often because of missing Open Cloud access, creator permission mismatches, or platform-side gating.".to_owned(),
+        "The place file may contain Roblox instance types the Place Publishing API does not update, such as EditableImage, EditableMesh, PartOperation, SurfaceAppearance, or BaseWrap.".to_owned(),
+        "The place file may be close to Roblox's practical upload limit or require Studio publishing instead of API publishing.".to_owned(),
+    ])
+    .with_next_steps(vec![
+        "Verify the Open Cloud key scope and universe restriction first.".to_owned(),
+        "Check the place for unsupported instance types and large file size, then retry.".to_owned(),
+        "If the same publish succeeds in Studio but not via API, treat it as a platform-side place publishing limitation and keep the rollout manual for that content.".to_owned(),
+    ])
+    .with_operation(context)
+}
+
+fn action_label(action: OperationAction) -> &'static str {
+    match action {
+        OperationAction::Preflight => "preflight",
+        OperationAction::Create => "create",
+        OperationAction::Update => "update",
+        OperationAction::Delete => "delete",
+        OperationAction::Rollback => "rollback",
+    }
+}
+
+fn context_detail_suffix(context: &OperationContext) -> String {
+    let mut parts = Vec::new();
+    if let Some(resource_id) = &context.resource_id {
+        parts.push(format!("resource {}", resource_id));
+    }
+    if let Some(endpoint) = &context.endpoint {
+        parts.push(format!("endpoint {}", endpoint));
+    }
+    if let Some(file_path) = &context.file_path {
+        parts.push(format!("file {}", file_path));
+    }
+    if let Some(creator_target) = &context.creator_target {
+        parts.push(format!("creator {}", creator_target));
+    }
+
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" [{}]", parts.join(", "))
+    }
+}
+fn validate_target_configuration(
+    target_config: &TargetConfig,
+    owner_config: &OwnerConfig,
+    report: &mut DiagnosticReport,
+) {
+    let TargetConfig::Experience(target_config) = target_config;
+    let playability = target_config
+        .configuration
+        .as_ref()
+        .and_then(|config| config.playability);
+
+    if matches!(owner_config, OwnerConfig::Group(_))
+        && matches!(playability, Some(PlayabilityTargetConfig::Friends))
+    {
+        report.push(
+            DeploymentDiagnostic::error(
+                "group-friends-access-unsupported",
+                DiagnosticCategory::Configuration,
+                "Group-owned experiences cannot use `playability: friends`.",
+            )
+            .with_detail(
+                "Roblox only exposes the Friends audience for user-owned experiences. Group-owned experiences must stay private, become public, or use the group-only audience in Creator Dashboard.",
+            )
+            .with_next_steps(vec![
+                "Change the environment or target playability to `private` or `public`.".to_owned(),
+                "If you need a group-only rollout, configure access in Creator Dashboard after deploy.".to_owned(),
+            ]),
+        );
+    }
+
+    if matches!(playability, Some(PlayabilityTargetConfig::Public)) {
+        report.push(
+            DeploymentDiagnostic::warning(
+                "public-experience-gating",
+                DiagnosticCategory::Preflight,
+                "Public experience updates can still be blocked by Roblox account and compliance requirements.",
+            )
+            .with_detail(
+                "Roblox documents additional gating for public experiences, including content maturity/compliance, account age, and account verification or purchase history. Lithos cannot verify those requirements ahead of time.",
+            )
+            .with_probable_causes(vec![
+                "The required content maturity questionnaire is incomplete for the experience.".to_owned(),
+                "The publishing account does not satisfy Roblox's eligibility requirements for public publishing.".to_owned(),
+            ])
+            .with_next_steps(vec![
+                "Confirm the experience can be switched to Public in Creator Dashboard before running CI deploys.".to_owned(),
+                "If Roblox later returns a vague 4xx/5xx, check the experience privacy settings, content maturity questionnaire, and account eligibility requirements first.".to_owned(),
+            ]),
+        );
+    }
+}
+
+fn validate_place_publish_auth(
+    existing_experience_id: Option<AssetId>,
+    auth: &PreflightAuthContext,
+    report: &mut DiagnosticReport,
+) {
+    if !auth.open_cloud_api_key_present {
+        report.push(
+            DeploymentDiagnostic::error(
+                "missing-open-cloud-key",
+                DiagnosticCategory::Authentication,
+                "Place publishing requires an Open Cloud API key (`LITHOS_OPEN_CLOUD_API_KEY` is preferred).",
+            )
+            .with_detail(
+                "Lithos uses Roblox's Place Publishing API for place file uploads. Without an Open Cloud API key, deploy cannot publish `.rbxl` or `.rbxlx` files.",
+            )
+            .with_next_steps(vec![
+                "Create an API key with the `universe-places` API and the `write` operation.".to_owned(),
+                "Export it as `LITHOS_OPEN_CLOUD_API_KEY` before running `lithos deploy`. Lithos also accepts `ROBLOX_OPEN_CLOUD_API_KEY`.".to_owned(),
+            ]),
+        );
+        return;
+    }
+
+    let Some(open_cloud_key) = auth.open_cloud_key.as_ref() else {
+        report.push(
+            DeploymentDiagnostic::warning(
+                "open-cloud-introspection-unavailable",
+                DiagnosticCategory::Preflight,
+                "Lithos could not verify the Open Cloud API key's scopes ahead of time.",
+            )
+            .with_confidence(DiagnosticConfidence::High)
+            .with_detail(
+                "The key is present, but preflight could not introspect its status or scope selection. Deploy will continue and classify any Roblox permission errors with more specific guidance if publishing fails.",
+            ),
+        );
+        return;
+    };
+
+    if !open_cloud_key.enabled {
+        report.push(
+            DeploymentDiagnostic::error(
+                "open-cloud-key-disabled",
+                DiagnosticCategory::Authentication,
+                "The configured Open Cloud API key is disabled.",
+            )
+            .with_detail(format!(
+                "Roblox reported that API key '{}' is disabled.",
+                open_cloud_key.name
+            ))
+            .with_next_steps(vec![
+                "Enable the API key in Creator Dashboard or replace it with an active key."
+                    .to_owned(),
+            ]),
+        );
+    }
+
+    if open_cloud_key.expired {
+        report.push(
+            DeploymentDiagnostic::error(
+                "open-cloud-key-expired",
+                DiagnosticCategory::Authentication,
+                "The configured Open Cloud API key is expired.",
+            )
+            .with_detail(format!(
+                "Roblox reported that API key '{}' is expired or auto-expired.",
+                open_cloud_key.name
+            ))
+            .with_next_steps(vec![
+                "Rotate or regenerate the API key in Creator Dashboard and update `LITHOS_OPEN_CLOUD_API_KEY` (or the legacy alias you are using).".to_owned(),
+            ]),
+        );
+    }
+
+    if !open_cloud_key.has_scope_operation("universe-places", "write") {
+        report.push(
+            DeploymentDiagnostic::error(
+                "missing-universe-places-write-scope",
+                DiagnosticCategory::Authorization,
+                "The Open Cloud API key cannot publish place versions.",
+            )
+            .with_detail(
+                "Roblox API key introspection did not find the `universe-places` API with the `write` operation.",
+            )
+            .with_next_steps(vec![
+                "Edit the API key in Creator Dashboard and add the `universe-places` API with `write` access.".to_owned(),
+            ]),
+        );
+        return;
+    }
+
+    match existing_experience_id {
+        Some(experience_id)
+            if !open_cloud_key.allows_universe_operation(
+                "universe-places",
+                "write",
+                experience_id,
+            ) =>
+        {
+            report.push(
+                DeploymentDiagnostic::error(
+                    "api-key-missing-target-universe",
+                    DiagnosticCategory::Authorization,
+                    "The Open Cloud API key does not include the target experience for place publishing.",
+                )
+                .with_detail(format!(
+                    "Roblox API key introspection found `universe-places.write`, but not for universe {}.",
+                    experience_id
+                ))
+                .with_next_steps(vec![
+                    "Edit the API key's experience restrictions and add the target universe, or disable the experience restriction for this key.".to_owned(),
+                ]),
+            );
+        }
+        None if open_cloud_key.has_scope_operation("universe-places", "write")
+            && !open_cloud_key.has_wildcard_universe_operation("universe-places", "write") =>
+        {
+            report.push(
+                DeploymentDiagnostic::warning(
+                    "api-key-new-universe-scope-inconclusive",
+                    DiagnosticCategory::Preflight,
+                    "Lithos cannot prove that the Open Cloud API key will cover a newly created experience.",
+                )
+                .with_confidence(DiagnosticConfidence::High)
+                .with_detail(
+                    "The API key has `universe-places.write`, but its scope is restricted to specific experiences. If this deploy creates a brand-new universe, the subsequent place publish may still fail until the key is updated.",
+                )
+                .with_next_steps(vec![
+                    "If this deploy creates a new experience, prefer a wildcard or newly updated API key before running automation.".to_owned(),
+                ]),
+            );
+        }
+        _ => {}
+    }
+}
+
+fn validate_place_file(
+    project_path: &Path,
+    resource_id: &str,
+    file_path: &str,
+    report: &mut DiagnosticReport,
+) {
+    let full_path = project_path.join(file_path);
+    let extension = extension_lowercase(&full_path);
+
+    if !matches!(extension.as_deref(), Some("rbxl" | "rbxlx")) {
+        report.push(
+            DeploymentDiagnostic::error(
+                "invalid-place-file-extension",
+                DiagnosticCategory::File,
+                format!(
+                    "{} points to a file that is not `.rbxl` or `.rbxlx`.",
+                    resource_id
+                ),
+            )
+            .with_detail(format!(
+                "Lithos can only publish Roblox place files. Received '{}'.",
+                file_path
+            ))
+            .with_operation(file_operation_context(
+                resource_id,
+                "PlaceFile",
+                file_path,
+            )),
+        );
+        return;
+    }
+
+    let Some(metadata) = read_metadata(&full_path, resource_id, "PlaceFile", file_path, report)
+    else {
+        return;
+    };
+
+    if metadata.len() > ROBLOX_PLACE_SIZE_LIMIT_BYTES {
+        let summary = match extension.as_deref() {
+            Some("rbxlx") => {
+                format!(
+                    "{} exceeds Roblox's documented 100 MB place publishing limit.",
+                    file_path
+                )
+            }
+            _ => format!(
+                "{} exceeds Roblox's documented 100 MB place publishing limit.",
+                file_path
+            ),
+        };
+        let detail = match extension.as_deref() {
+            Some("rbxlx") => "Roblox documents a 100 MB limit for published places. XML place files are usually larger than their binary `.rbxl` equivalent and are more likely to hit this limit.".to_owned(),
+            _ => "Roblox documents a 100 MB limit for published places. Files above that limit often fail with vague server errors during publish.".to_owned(),
+        };
+
+        report.push(
+            DeploymentDiagnostic::error(
+                "place-file-too-large",
+                DiagnosticCategory::File,
+                summary,
+            )
+            .with_detail(detail)
+            .with_next_steps(vec![
+                "Reduce the size of the place file before deploying.".to_owned(),
+                "If the file is `.rbxlx`, export a binary `.rbxl` build and deploy that instead.".to_owned(),
+            ])
+            .with_operation(file_operation_context(resource_id, "PlaceFile", file_path)),
+        );
+        return;
+    }
+
+    if metadata.len() >= ROBLOX_PLACE_WARNING_BYTES {
+        report.push(
+            DeploymentDiagnostic::warning(
+                "place-file-near-limit",
+                DiagnosticCategory::File,
+                format!("{} is close to Roblox's 100 MB place publishing limit.", file_path),
+            )
+            .with_confidence(DiagnosticConfidence::High)
+            .with_detail(match extension.as_deref() {
+                Some("rbxlx") => "Large `.rbxlx` files frequently hit publishing limits before the raw file size looks extreme. Roblox recommends using `.rbxl` when size becomes an issue.".to_owned(),
+                _ => "Large place files can fail during publish with vague server responses even before they cross the documented hard limit.".to_owned(),
+            })
+            .with_operation(file_operation_context(resource_id, "PlaceFile", file_path)),
+        );
+    }
+}
+
+fn validate_file_extension(
+    project_path: &Path,
+    resource_id: &str,
+    file_path: &str,
+    allowed_extensions: &[&str],
+    file_kind: &str,
+    report: &mut DiagnosticReport,
+) {
+    let full_path = project_path.join(file_path);
+    let extension = extension_lowercase(&full_path);
+    if !matches!(extension.as_deref(), Some(value) if allowed_extensions.contains(&value)) {
+        report.push(
+            DeploymentDiagnostic::error(
+                "invalid-file-extension",
+                DiagnosticCategory::File,
+                format!(
+                    "{} must reference a supported {} file.",
+                    resource_id, file_kind
+                ),
+            )
+            .with_detail(format!(
+                "Expected one of [{}] but received '{}'.",
+                allowed_extensions.join(", "),
+                file_path
+            ))
+            .with_operation(file_operation_context(
+                resource_id,
+                resource_id,
+                file_path,
+            )),
+        );
+        return;
+    }
+
+    let _ = read_metadata(&full_path, resource_id, resource_id, file_path, report);
+}
+
+fn read_metadata(
+    full_path: &Path,
+    resource_id: &str,
+    resource_type: &str,
+    file_path: &str,
+    report: &mut DiagnosticReport,
+) -> Option<fs::Metadata> {
+    match fs::metadata(full_path) {
+        Ok(metadata) => Some(metadata),
+        Err(error) => {
+            report.push(
+                DeploymentDiagnostic::error(
+                    "missing-local-file",
+                    DiagnosticCategory::File,
+                    format!("{} references a file that does not exist at apply time.", resource_id),
+                )
+                .with_detail(format!("{} ({})", file_path, error))
+                .with_next_steps(vec![
+                    "Restore the file in your working tree before deploying.".to_owned(),
+                    "If you are trying to undo a deploy, check out the commit that produced the last known good snapshot first.".to_owned(),
+                ])
+                .with_operation(file_operation_context(resource_id, resource_type, file_path)),
+            );
+            None
+        }
+    }
+}
+
+fn extension_lowercase(path: &Path) -> Option<String> {
+    path.extension()
+        .and_then(|value| value.to_str())
+        .map(|value| value.to_ascii_lowercase())
+}
+
+fn file_operation_context(
+    resource_id: &str,
+    resource_type: &str,
+    file_path: &str,
+) -> OperationContext {
+    OperationContext {
+        action: OperationAction::Preflight,
+        resource_id: Some(resource_id.to_owned()),
+        resource_type: resource_type.to_owned(),
+        auth_model: "preflight".to_owned(),
+        creator_target: None,
+        endpoint: None,
+        file_path: Some(file_path.to_owned()),
+    }
+}
+
+#[cfg(test)]
+fn empty_experience_target() -> crate::config::ExperienceTargetConfig {
+    crate::config::ExperienceTargetConfig {
+        configuration: None,
+        places: None,
+        icon: None,
+        thumbnails: None,
+        social_links: None,
+        products: None,
+        passes: None,
+        badges: None,
+        assets: None,
+        spatial_voice: None,
+        notifications: None,
+    }
+}
+
+trait StringCasingExt {
+    fn to_uppercase_first(&self) -> String;
+}
+
+impl StringCasingExt for str {
+    fn to_uppercase_first(&self) -> String {
+        let mut chars = self.chars();
+        match chars.next() {
+            Some(first) => format!("{}{}", first.to_ascii_uppercase(), chars.as_str()),
+            None => String::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use rbx_api::api_keys::models::{ApiKeyScope, IntrospectApiKeyResponse};
+    use reqwest::StatusCode;
+
+    use super::*;
+    use crate::roblox_resource_manager::{
+        outputs::{AssetOutputs, ExperienceOutputs},
+        ExperienceInputs, FileInputs, PlaceInputs,
+    };
+
+    struct TempProject {
+        path: PathBuf,
+    }
+
+    impl TempProject {
+        fn new() -> Self {
+            let unique = format!(
+                "lithos-diagnostics-{}-{}",
+                std::process::id(),
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            );
+            let path = std::env::temp_dir().join(unique);
+            fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+
+        fn write_file(&self, relative: &str, size: usize) {
+            let file_path = self.path.join(relative);
+            if let Some(parent) = file_path.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(file_path, vec![0u8; size]).unwrap();
+        }
+    }
+
+    impl Drop for TempProject {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn existing_graph(
+        universe_id: u64,
+    ) -> ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs> {
+        let experience = RobloxResource::existing(
+            "experience_singleton",
+            RobloxInputs::Experience(ExperienceInputs { group_id: None }),
+            RobloxOutputs::Experience(ExperienceOutputs {
+                asset_id: universe_id,
+                start_place_id: 9001,
+            }),
+            &[],
+        );
+        let start_place = RobloxResource::existing(
+            "place_start",
+            RobloxInputs::Place(PlaceInputs { is_start: true }),
+            RobloxOutputs::Place(AssetOutputs { asset_id: 9001 }),
+            &[&experience],
+        );
+        ResourceGraph::new(&[experience, start_place])
+    }
+
+    fn desired_graph(
+        file_path: &str,
+    ) -> ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs> {
+        let experience = RobloxResource::new(
+            "experience_singleton",
+            RobloxInputs::Experience(ExperienceInputs { group_id: None }),
+            &[],
+        );
+        let start_place = RobloxResource::new(
+            "place_start",
+            RobloxInputs::Place(PlaceInputs { is_start: true }),
+            &[&experience],
+        );
+        let place_file = RobloxResource::new(
+            "placeFile_start",
+            RobloxInputs::PlaceFile(FileInputs {
+                file_path: file_path.to_owned(),
+                file_hash: "hash".to_owned(),
+            }),
+            &[&start_place, &experience],
+        );
+        ResourceGraph::new(&[experience, start_place, place_file])
+    }
+
+    #[test]
+    fn blocks_place_publish_without_open_cloud_key() {
+        let temp = TempProject::new();
+        temp.write_file("game.rbxl", 128);
+
+        let report = run_preflight_checks(
+            temp.path(),
+            &TargetConfig::Experience(empty_experience_target()),
+            &OwnerConfig::Personal,
+            &existing_graph(123),
+            &desired_graph("game.rbxl"),
+            &PreflightAuthContext::default(),
+        );
+
+        assert!(report.has_blocking());
+        assert!(report
+            .blocking
+            .iter()
+            .any(|diagnostic| diagnostic.code == "missing-open-cloud-key"));
+    }
+
+    #[test]
+    fn blocks_scope_mismatch_for_existing_universe() {
+        let temp = TempProject::new();
+        temp.write_file("game.rbxl", 128);
+
+        let report = run_preflight_checks(
+            temp.path(),
+            &TargetConfig::Experience(empty_experience_target()),
+            &OwnerConfig::Personal,
+            &existing_graph(123),
+            &desired_graph("game.rbxl"),
+            &PreflightAuthContext {
+                open_cloud_api_key_present: true,
+                open_cloud_key: Some(IntrospectApiKeyResponse {
+                    name: "ci-key".to_owned(),
+                    authorized_user_id: Some(1),
+                    scopes: vec![ApiKeyScope {
+                        name: "universe-places".to_owned(),
+                        operations: vec!["write".to_owned()],
+                        user_ids: Vec::new(),
+                        group_ids: Vec::new(),
+                        universe_ids: vec!["999".to_owned()],
+                    }],
+                    enabled: true,
+                    expired: false,
+                    expiration_time_utc: None,
+                }),
+            },
+        );
+
+        assert!(report
+            .blocking
+            .iter()
+            .any(|diagnostic| diagnostic.code == "api-key-missing-target-universe"));
+    }
+
+    #[test]
+    fn warns_when_place_file_is_near_size_limit() {
+        let temp = TempProject::new();
+        temp.write_file("large.rbxlx", ROBLOX_PLACE_WARNING_BYTES as usize);
+
+        let report = run_preflight_checks(
+            temp.path(),
+            &TargetConfig::Experience(empty_experience_target()),
+            &OwnerConfig::Personal,
+            &existing_graph(123),
+            &desired_graph("large.rbxlx"),
+            &PreflightAuthContext {
+                open_cloud_api_key_present: true,
+                open_cloud_key: Some(IntrospectApiKeyResponse {
+                    name: "ci-key".to_owned(),
+                    authorized_user_id: Some(1),
+                    scopes: vec![ApiKeyScope {
+                        name: "universe-places".to_owned(),
+                        operations: vec!["write".to_owned()],
+                        user_ids: Vec::new(),
+                        group_ids: Vec::new(),
+                        universe_ids: vec!["*".to_owned()],
+                    }],
+                    enabled: true,
+                    expired: false,
+                    expiration_time_utc: None,
+                }),
+            },
+        );
+
+        assert!(report
+            .warnings
+            .iter()
+            .any(|diagnostic| diagnostic.code == "place-file-near-limit"));
+    }
+
+    #[test]
+    fn blocks_group_friends_access() {
+        let temp = TempProject::new();
+        temp.write_file("game.rbxl", 128);
+
+        let mut target = empty_experience_target();
+        target.configuration = Some(crate::config::ExperienceTargetConfigurationConfig {
+            playability: Some(PlayabilityTargetConfig::Friends),
+            ..Default::default()
+        });
+
+        let report = run_preflight_checks(
+            temp.path(),
+            &TargetConfig::Experience(target),
+            &OwnerConfig::Group(42),
+            &existing_graph(123),
+            &desired_graph("game.rbxl"),
+            &PreflightAuthContext {
+                open_cloud_api_key_present: true,
+                open_cloud_key: Some(IntrospectApiKeyResponse {
+                    name: "ci-key".to_owned(),
+                    authorized_user_id: Some(1),
+                    scopes: vec![ApiKeyScope {
+                        name: "universe-places".to_owned(),
+                        operations: vec!["write".to_owned()],
+                        user_ids: Vec::new(),
+                        group_ids: Vec::new(),
+                        universe_ids: vec!["*".to_owned()],
+                    }],
+                    enabled: true,
+                    expired: false,
+                    expiration_time_utc: None,
+                }),
+            },
+        );
+
+        assert!(report
+            .blocking
+            .iter()
+            .any(|diagnostic| diagnostic.code == "group-friends-access-unsupported"));
+    }
+
+    #[test]
+    fn classifies_place_publish_permission_denied() {
+        let error = map_roblox_api_error(
+            OperationContext {
+                action: OperationAction::Update,
+                resource_id: Some("placeFile_start".to_owned()),
+                resource_type: "PlaceFile".to_owned(),
+                auth_model: "open-cloud".to_owned(),
+                creator_target: Some("group:42".to_owned()),
+                endpoint: Some("publish_place_version".to_owned()),
+                file_path: Some("game.rbxl".to_owned()),
+            },
+            &RobloxApiError::Roblox {
+                status_code: StatusCode::FORBIDDEN,
+                reason: "Forbidden".to_owned(),
+            },
+        );
+
+        assert_eq!(
+            error.summary(),
+            "Roblox denied the place publishing request."
+        );
+        assert!(error
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.code == "place-publish-permission-denied"));
+    }
+
+    #[test]
+    fn classifies_group_experience_vague_server_failure() {
+        let error = map_roblox_api_error(
+            OperationContext {
+                action: OperationAction::Create,
+                resource_id: Some("experience_singleton".to_owned()),
+                resource_type: "Experience".to_owned(),
+                auth_model: "cookie-session".to_owned(),
+                creator_target: Some("group:42".to_owned()),
+                endpoint: Some("create_experience".to_owned()),
+                file_path: None,
+            },
+            &RobloxApiError::Roblox {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                reason: "Internal Server Error".to_owned(),
+            },
+        );
+
+        assert!(error
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.code == "group-experience-create-vague-failure"));
+    }
+}

--- a/rbx_lithos/src/lib.rs
+++ b/rbx_lithos/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod diagnostics;
 pub mod project;
 pub mod resource_graph;
 pub mod roblox_resource_manager;

--- a/rbx_lithos/src/project.rs
+++ b/rbx_lithos/src/project.rs
@@ -223,8 +223,11 @@ pub async fn load_project(
     let state = get_previous_state(project_path.as_path(), &config, environment_config).await?;
 
     // Get our resource graphs
-    let previous_graph =
-        ResourceGraph::new(state.environments.get(&environment_config.label).unwrap());
+    let previous_graph = ResourceGraph::new(
+        state
+            .current_resources(&environment_config.label)
+            .unwrap_or(&Vec::new()),
+    );
 
     Ok(Some(Project {
         current_graph: previous_graph,

--- a/rbx_lithos/src/resource_graph.rs
+++ b/rbx_lithos/src/resource_graph.rs
@@ -8,6 +8,8 @@ use difference::Changeset;
 use serde::Serialize;
 use yansi::Paint;
 
+use crate::diagnostics::OperationError;
+
 macro_rules! all_outputs {
     ($expr:expr, $enum:path) => {{
         $expr
@@ -56,40 +58,60 @@ pub trait Resource<TInputs, TOutputs>: Clone {
 pub trait ResourceManager<TInputs, TOutputs> {
     async fn get_create_price(
         &self,
+        resource_id: &str,
         inputs: TInputs,
         dependency_outputs: Vec<TOutputs>,
-    ) -> Result<Option<u32>, String>;
+    ) -> Result<Option<u32>, OperationError>;
 
     async fn create(
         &self,
+        resource_id: &str,
         inputs: TInputs,
         dependency_outputs: Vec<TOutputs>,
         price: Option<u32>,
-    ) -> Result<TOutputs, String>;
+    ) -> Result<TOutputs, OperationError>;
 
     async fn get_update_price(
         &self,
+        resource_id: &str,
         inputs: TInputs,
         outputs: TOutputs,
         dependency_outputs: Vec<TOutputs>,
-    ) -> Result<Option<u32>, String>;
+    ) -> Result<Option<u32>, OperationError>;
 
     async fn update(
         &self,
+        resource_id: &str,
         inputs: TInputs,
         outputs: TOutputs,
         dependency_outputs: Vec<TOutputs>,
         price: Option<u32>,
-    ) -> Result<TOutputs, String>;
+    ) -> Result<TOutputs, OperationError>;
 
     async fn delete(
         &self,
+        resource_id: &str,
         outputs: TOutputs,
         dependency_outputs: Vec<TOutputs>,
+    ) -> Result<(), OperationError>;
+}
+
+#[async_trait(?Send)]
+pub trait EvaluateProgressHandler<TResource, TInputs, TOutputs>
+where
+    TResource: Resource<TInputs, TOutputs>,
+    TInputs: Clone,
+    TOutputs: Clone + Serialize,
+{
+    async fn persist_progress(
+        &mut self,
+        current_graph: &ResourceGraph<TResource, TInputs, TOutputs>,
+        results: &EvaluateResults,
+        failures: &[ResourceFailure],
     ) -> Result<(), String>;
 }
 
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct EvaluateResults {
     pub created_count: u32,
     pub updated_count: u32,
@@ -101,11 +123,50 @@ pub struct EvaluateResults {
 enum OperationResult<TOutputs> {
     Skipped(String),
     Noop,
-    Failed(String),
+    Failed(OperationError),
     SucceededDelete,
     SucceededCreate(TOutputs),
     SucceededUpdate(TOutputs),
 }
+
+#[derive(Debug, Clone)]
+pub struct ResourceFailure {
+    pub resource_id: ResourceId,
+    pub error: OperationError,
+}
+
+#[derive(Debug, Clone)]
+pub struct EvaluateError {
+    pub results: EvaluateResults,
+    pub failures: Vec<ResourceFailure>,
+}
+
+enum ProgressEvent {
+    None,
+    Mutation,
+}
+
+impl EvaluateError {
+    pub fn failure_count(&self) -> usize {
+        self.failures.len()
+    }
+
+    pub fn applied_mutation_count(&self) -> u32 {
+        self.results.created_count + self.results.updated_count + self.results.deleted_count
+    }
+}
+
+impl std::fmt::Display for EvaluateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Failed {} change(s) while evaluating the resource graph.",
+            self.failures.len()
+        )
+    }
+}
+
+impl std::error::Error for EvaluateError {}
 
 fn get_changeset(previous_hash: &str, new_hash: &str) -> Changeset {
     Changeset::new(previous_hash, new_hash, "\n")
@@ -230,10 +291,11 @@ where
         &mut self,
         results: &mut EvaluateResults,
         failures_count: &mut u32,
+        failures: &mut Vec<ResourceFailure>,
         previous_graph: &ResourceGraph<TResource, TInputs, TOutputs>,
         resource_id: &str,
         operation_result: OperationResult<TOutputs>,
-    ) {
+    ) -> ProgressEvent {
         // TODO: Improve DRY here
         match operation_result {
             OperationResult::SucceededDelete => {
@@ -244,6 +306,7 @@ where
                     "Succeeded with outputs:",
                     get_changeset(&previous_resource.get_outputs_hash(), ""),
                 );
+                ProgressEvent::Mutation
             }
             OperationResult::SucceededCreate(outputs) => {
                 // Update the resource with the new outputs
@@ -255,6 +318,7 @@ where
                     "Succeeded with outputs:",
                     get_changeset("", &resource.get_outputs_hash()),
                 );
+                ProgressEvent::Mutation
             }
             OperationResult::SucceededUpdate(outputs) => {
                 // Update the resource with the new outputs
@@ -270,6 +334,7 @@ where
                         &resource.get_outputs_hash(),
                     ),
                 );
+                ProgressEvent::Mutation
             }
             OperationResult::Noop => {
                 // There was no need to create or update the resource. We will update the resource
@@ -283,6 +348,7 @@ where
                 );
 
                 results.noop_count += 1;
+                ProgressEvent::None
             }
             OperationResult::Skipped(reason) => {
                 // The resource was not evaluated. If the resource existed previously, we will copy
@@ -297,6 +363,7 @@ where
 
                 results.skipped_count += 1;
                 logger::end_action(format!("Skipped: {}", Paint::yellow(reason)));
+                ProgressEvent::None
             }
             OperationResult::Failed(error) => {
                 // An error occurred while creating or updating the resource. If the
@@ -310,9 +377,50 @@ where
                 }
 
                 *failures_count += 1;
-                logger::end_action(format!("Failed: {}", Paint::red(error)));
+                failures.push(ResourceFailure {
+                    resource_id: resource_id.to_owned(),
+                    error: error.clone(),
+                });
+                for diagnostic in error.diagnostics() {
+                    if let Some(detail) = &diagnostic.detail {
+                        logger::log(format!("  {}", detail));
+                    }
+                    for cause in &diagnostic.probable_causes {
+                        logger::log(format!("  likely: {}", cause));
+                    }
+                    for next_step in &diagnostic.next_steps {
+                        logger::log(format!("  next: {}", next_step));
+                    }
+                }
+                logger::end_action(format!("Failed: {}", Paint::red(error.summary())));
+                ProgressEvent::None
             }
         }
+    }
+
+    async fn persist_evaluate_progress(
+        &self,
+        progress: &mut dyn EvaluateProgressHandler<TResource, TInputs, TOutputs>,
+        results: &EvaluateResults,
+        failures: &[ResourceFailure],
+        resource_id: &str,
+    ) -> Result<(), EvaluateError> {
+        progress
+            .persist_progress(self, results, failures)
+            .await
+            .map_err(|error| EvaluateError {
+                results: results.clone(),
+                failures: vec![ResourceFailure {
+                    resource_id: resource_id.to_owned(),
+                    error: OperationError::new(
+                        format!(
+                            "Failed to persist deployment progress after applying {}\n\t{}",
+                            resource_id, error
+                        ),
+                        Vec::new(),
+                    ),
+                }],
+            })
     }
 
     async fn evaluate_delete<TManager>(
@@ -343,6 +451,7 @@ where
 
         match manager
             .delete(
+                resource_id,
                 resource
                     .get_outputs()
                     .expect("Existing resource should have outputs."),
@@ -417,6 +526,7 @@ where
 
             let price = match manager
                 .get_update_price(
+                    resource_id,
                     resource.get_inputs(),
                     outputs.clone(),
                     dependency_outputs.clone(),
@@ -443,7 +553,13 @@ where
             };
 
             match manager
-                .update(resource.get_inputs(), outputs, dependency_outputs, price)
+                .update(
+                    resource_id,
+                    resource.get_inputs(),
+                    outputs,
+                    dependency_outputs,
+                    price,
+                )
                 .await
             {
                 Ok(outputs) => OperationResult::SucceededUpdate(outputs),
@@ -469,7 +585,11 @@ where
             logger::log_changeset(get_changeset("", &inputs_hash));
 
             let price = match manager
-                .get_create_price(resource.get_inputs(), dependency_outputs.clone())
+                .get_create_price(
+                    resource_id,
+                    resource.get_inputs(),
+                    dependency_outputs.clone(),
+                )
                 .await
             {
                 Ok(Some(price)) if price > 0 => {
@@ -492,7 +612,12 @@ where
             };
 
             match manager
-                .create(resource.get_inputs(), dependency_outputs, price)
+                .create(
+                    resource_id,
+                    resource.get_inputs(),
+                    dependency_outputs,
+                    price,
+                )
                 .await
             {
                 Ok(outputs) => OperationResult::SucceededCreate(outputs),
@@ -506,15 +631,39 @@ where
         previous_graph: &ResourceGraph<TResource, TInputs, TOutputs>,
         manager: &mut TManager,
         allow_purchases: bool,
-    ) -> Result<EvaluateResults, String>
+    ) -> Result<EvaluateResults, EvaluateError>
+    where
+        TManager: ResourceManager<TInputs, TOutputs>,
+    {
+        self.evaluate_with_progress(previous_graph, manager, allow_purchases, None)
+            .await
+    }
+
+    pub async fn evaluate_with_progress<TManager>(
+        &mut self,
+        previous_graph: &ResourceGraph<TResource, TInputs, TOutputs>,
+        manager: &mut TManager,
+        allow_purchases: bool,
+        mut progress: Option<&mut dyn EvaluateProgressHandler<TResource, TInputs, TOutputs>>,
+    ) -> Result<EvaluateResults, EvaluateError>
     where
         TManager: ResourceManager<TInputs, TOutputs>,
     {
         let mut results = EvaluateResults::default();
         let mut failures_count: u32 = 0;
+        let mut failures: Vec<ResourceFailure> = Vec::new();
 
         // Iterate over previous resources in reverse order so that leaf resources are removed first
-        let mut previous_resource_order = previous_graph.get_topological_order()?;
+        let mut previous_resource_order =
+            previous_graph
+                .get_topological_order()
+                .map_err(|error| EvaluateError {
+                    results: results.clone(),
+                    failures: vec![ResourceFailure {
+                        resource_id: "resource-graph".to_owned(),
+                        error: OperationError::new(error.clone(), Vec::new()),
+                    }],
+                })?;
         previous_resource_order.reverse();
         for resource_id in previous_resource_order.iter() {
             if self.resources.contains_key(resource_id) {
@@ -524,41 +673,70 @@ where
             let operation_result: OperationResult<TOutputs> = self
                 .evaluate_delete(previous_graph, manager, resource_id)
                 .await;
-            self.handle_operation_result(
+            let progress_event = self.handle_operation_result(
                 &mut results,
                 &mut failures_count,
+                &mut failures,
                 previous_graph,
                 resource_id,
                 operation_result,
             );
+            if matches!(progress_event, ProgressEvent::Mutation) {
+                if let Some(progress_handler) = progress.as_mut() {
+                    self.persist_evaluate_progress(
+                        *progress_handler,
+                        &results,
+                        &failures,
+                        resource_id,
+                    )
+                    .await?;
+                }
+            }
         }
 
-        let resource_order = self.get_topological_order()?;
+        let resource_order = self
+            .get_topological_order()
+            .map_err(|error| EvaluateError {
+                results: results.clone(),
+                failures: vec![ResourceFailure {
+                    resource_id: "resource-graph".to_owned(),
+                    error: OperationError::new(error.clone(), Vec::new()),
+                }],
+            })?;
         for resource_id in resource_order.iter() {
             let operation_result = self
                 .evaluate_create_or_update(previous_graph, manager, resource_id, allow_purchases)
                 .await;
-            self.handle_operation_result(
+            let progress_event = self.handle_operation_result(
                 &mut results,
                 &mut failures_count,
+                &mut failures,
                 previous_graph,
                 resource_id,
                 operation_result,
             );
+            if matches!(progress_event, ProgressEvent::Mutation) {
+                if let Some(progress_handler) = progress.as_mut() {
+                    self.persist_evaluate_progress(
+                        *progress_handler,
+                        &results,
+                        &failures,
+                        resource_id,
+                    )
+                    .await?;
+                }
+            }
         }
 
         if failures_count > 0 {
-            Err(format!(
-                "Failed {} changes(s) while evaluating the resource graph. See above for more details.",
-                failures_count
-            ))
+            Err(EvaluateError { results, failures })
         } else {
             Ok(results)
         }
     }
 
     pub fn diff(
-        &mut self,
+        &self,
         previous_graph: &ResourceGraph<TResource, TInputs, TOutputs>,
     ) -> Result<ResourceGraphDiff, String> {
         let mut diff = ResourceGraphDiff {
@@ -644,6 +822,190 @@ where
         }
 
         Ok(diff)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct TestResource {
+        id: String,
+        inputs: String,
+        outputs: Option<String>,
+        dependencies: Vec<ResourceId>,
+    }
+
+    impl TestResource {
+        fn new(id: &str) -> Self {
+            Self {
+                id: id.to_owned(),
+                inputs: id.to_owned(),
+                outputs: None,
+                dependencies: Vec::new(),
+            }
+        }
+    }
+
+    impl Resource<String, String> for TestResource {
+        fn get_id(&self) -> ResourceId {
+            self.id.clone()
+        }
+
+        fn get_inputs_hash(&self) -> String {
+            self.inputs.clone()
+        }
+
+        fn get_outputs_hash(&self) -> String {
+            self.outputs.clone().unwrap_or_default()
+        }
+
+        fn get_inputs(&self) -> String {
+            self.inputs.clone()
+        }
+
+        fn get_outputs(&self) -> Option<String> {
+            self.outputs.clone()
+        }
+
+        fn get_dependencies(&self) -> Vec<ResourceId> {
+            self.dependencies.clone()
+        }
+
+        fn set_outputs(&mut self, outputs: String) {
+            self.outputs = Some(outputs);
+        }
+    }
+
+    struct TestManager;
+
+    #[async_trait]
+    impl ResourceManager<String, String> for TestManager {
+        async fn get_create_price(
+            &self,
+            _resource_id: &str,
+            _inputs: String,
+            _dependency_outputs: Vec<String>,
+        ) -> Result<Option<u32>, OperationError> {
+            Ok(None)
+        }
+
+        async fn create(
+            &self,
+            resource_id: &str,
+            _inputs: String,
+            _dependency_outputs: Vec<String>,
+            _price: Option<u32>,
+        ) -> Result<String, OperationError> {
+            Ok(format!("created:{}", resource_id))
+        }
+
+        async fn get_update_price(
+            &self,
+            _resource_id: &str,
+            _inputs: String,
+            _outputs: String,
+            _dependency_outputs: Vec<String>,
+        ) -> Result<Option<u32>, OperationError> {
+            Ok(None)
+        }
+
+        async fn update(
+            &self,
+            resource_id: &str,
+            _inputs: String,
+            _outputs: String,
+            _dependency_outputs: Vec<String>,
+            _price: Option<u32>,
+        ) -> Result<String, OperationError> {
+            Ok(format!("updated:{}", resource_id))
+        }
+
+        async fn delete(
+            &self,
+            _resource_id: &str,
+            _outputs: String,
+            _dependency_outputs: Vec<String>,
+        ) -> Result<(), OperationError> {
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingProgress {
+        applied_counts: Vec<u32>,
+    }
+
+    #[async_trait(?Send)]
+    impl EvaluateProgressHandler<TestResource, String, String> for RecordingProgress {
+        async fn persist_progress(
+            &mut self,
+            _current_graph: &ResourceGraph<TestResource, String, String>,
+            results: &EvaluateResults,
+            _failures: &[ResourceFailure],
+        ) -> Result<(), String> {
+            self.applied_counts
+                .push(results.created_count + results.updated_count + results.deleted_count);
+            Ok(())
+        }
+    }
+
+    struct FailingProgress {
+        calls: u32,
+    }
+
+    #[async_trait(?Send)]
+    impl EvaluateProgressHandler<TestResource, String, String> for FailingProgress {
+        async fn persist_progress(
+            &mut self,
+            _current_graph: &ResourceGraph<TestResource, String, String>,
+            _results: &EvaluateResults,
+            _failures: &[ResourceFailure],
+        ) -> Result<(), String> {
+            self.calls += 1;
+            Err("disk full".to_owned())
+        }
+    }
+
+    #[tokio::test]
+    async fn evaluate_with_progress_persists_after_each_mutation() {
+        let previous_graph = ResourceGraph::new(&[] as &[TestResource]);
+        let mut next_graph =
+            ResourceGraph::new(&[TestResource::new("alpha"), TestResource::new("beta")]);
+        let mut manager = TestManager;
+        let mut progress = RecordingProgress::default();
+
+        let results = next_graph
+            .evaluate_with_progress(&previous_graph, &mut manager, false, Some(&mut progress))
+            .await
+            .unwrap();
+
+        assert_eq!(results.created_count, 2);
+        assert_eq!(progress.applied_counts, vec![1, 2]);
+    }
+
+    #[tokio::test]
+    async fn evaluate_with_progress_returns_error_when_persistence_fails() {
+        let previous_graph = ResourceGraph::new(&[] as &[TestResource]);
+        let mut next_graph = ResourceGraph::new(&[TestResource::new("alpha")]);
+        let mut manager = TestManager;
+        let mut progress = FailingProgress { calls: 0 };
+
+        let error = next_graph
+            .evaluate_with_progress(&previous_graph, &mut manager, false, Some(&mut progress))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.applied_mutation_count(), 1);
+        assert_eq!(error.failure_count(), 1);
+        assert_eq!(error.failures[0].resource_id, "alpha");
+        assert!(error.failures[0]
+            .error
+            .summary()
+            .contains("Failed to persist deployment progress after applying alpha"));
     }
 }
 

--- a/rbx_lithos/src/roblox_resource_manager.rs
+++ b/rbx_lithos/src/roblox_resource_manager.rs
@@ -23,11 +23,17 @@ use std::{
 
 use async_trait::async_trait;
 use log::info;
-use rbx_api::{models::CreatorType, user::models::GetAuthenticatedUserResponse, RobloxApi};
+use rbx_api::{
+    api_keys::models::IntrospectApiKeyResponse, errors::RobloxApiError, models::CreatorType,
+    user::models::GetAuthenticatedUserResponse, RobloxApi,
+};
 use rbx_auth::{RobloxCookieStore, RobloxCsrfTokenStore};
 use rbxcloud::rbx::v1::RbxCloud;
 use yansi::Paint;
 
+use crate::diagnostics::{
+    map_operation_message, map_roblox_api_error, OperationAction, OperationContext, OperationError,
+};
 use crate::resource_graph::ResourceManager;
 
 pub mod inputs;
@@ -51,20 +57,39 @@ pub use resource::RobloxResource;
 pub struct RobloxResourceManager {
     pub(super) roblox_api: RobloxApi,
     pub(super) roblox_cloud: Option<RbxCloud>,
+    pub(super) open_cloud_api_key: Option<String>,
     pub(super) project_path: PathBuf,
     pub(super) payment_source: CreatorType,
     pub(super) user: GetAuthenticatedUserResponse,
 }
 
+fn load_open_cloud_api_key() -> Option<String> {
+    for (name, value) in [
+        (
+            "LITHOS_OPEN_CLOUD_API_KEY",
+            env::var("LITHOS_OPEN_CLOUD_API_KEY").ok(),
+        ),
+        (
+            "ROBLOX_OPEN_CLOUD_API_KEY",
+            env::var("ROBLOX_OPEN_CLOUD_API_KEY").ok(),
+        ),
+        (
+            "MANTLE_OPEN_CLOUD_API_KEY",
+            env::var("MANTLE_OPEN_CLOUD_API_KEY").ok(),
+        ),
+    ] {
+        if let Some(value) = value {
+            info!("Loaded Open Cloud API key from {}.", name);
+            return Some(value);
+        }
+    }
+
+    None
+}
+
 impl RobloxResourceManager {
     pub async fn new(project_path: &Path, payment_source: CreatorType) -> Result<Self, String> {
-        let open_cloud_api_key = match env::var("ROBLOX_OPEN_CLOUD_API_KEY") {
-            Ok(v) => {
-                info!("Loaded Open Cloud API key from ROBLOX_OPEN_CLOUD_API_KEY.");
-                Some(v)
-            }
-            Err(_) => None,
-        };
+        let open_cloud_api_key = load_open_cloud_api_key();
 
         let cookie_store = Arc::new(RobloxCookieStore::new()?);
         let csrf_token_store = RobloxCsrfTokenStore::new();
@@ -89,11 +114,14 @@ impl RobloxResourceManager {
             }
         };
 
-        let roblox_cloud = open_cloud_api_key.map(|api_key| RbxCloud::new(&api_key));
+        let roblox_cloud = open_cloud_api_key
+            .as_ref()
+            .map(|api_key| RbxCloud::new(api_key));
 
         Ok(Self {
             roblox_api,
             roblox_cloud,
+            open_cloud_api_key,
             project_path: project_path.to_path_buf(),
             payment_source,
             user,
@@ -111,51 +139,248 @@ impl RobloxResourceManager {
     pub fn api(&self) -> &RobloxApi {
         &self.roblox_api
     }
+
+    pub fn has_open_cloud_api_key(&self) -> bool {
+        self.open_cloud_api_key.is_some()
+    }
+
+    pub async fn introspect_open_cloud_api_key(
+        &self,
+    ) -> Result<Option<IntrospectApiKeyResponse>, RobloxApiError> {
+        let Some(api_key) = self.open_cloud_api_key.as_ref() else {
+            return Ok(None);
+        };
+
+        self.roblox_api.introspect_api_key(api_key).await.map(Some)
+    }
+
+    pub fn context_for_inputs(
+        &self,
+        action: OperationAction,
+        resource_id: &str,
+        inputs: &RobloxInputs,
+    ) -> OperationContext {
+        OperationContext {
+            action,
+            resource_id: Some(resource_id.to_owned()),
+            resource_type: resource_type_for_inputs(inputs).to_owned(),
+            auth_model: auth_model_for_inputs(self, inputs).to_owned(),
+            creator_target: creator_target_for_inputs(inputs),
+            endpoint: None,
+            file_path: file_path_for_inputs(inputs),
+        }
+    }
+
+    pub fn context_for_outputs(
+        &self,
+        action: OperationAction,
+        resource_id: &str,
+        outputs: &RobloxOutputs,
+    ) -> OperationContext {
+        OperationContext {
+            action,
+            resource_id: Some(resource_id.to_owned()),
+            resource_type: resource_type_for_outputs(outputs).to_owned(),
+            auth_model: auth_model_for_outputs(self, outputs).to_owned(),
+            creator_target: None,
+            endpoint: None,
+            file_path: None,
+        }
+    }
+
+    pub fn wrap_api_result<T>(
+        &self,
+        context: OperationContext,
+        result: Result<T, RobloxApiError>,
+    ) -> Result<T, OperationError> {
+        result.map_err(|error| map_roblox_api_error(context, &error))
+    }
+
+    pub fn wrap_message_result<T>(
+        &self,
+        context: OperationContext,
+        result: Result<T, String>,
+    ) -> Result<T, OperationError> {
+        result.map_err(|message| map_operation_message(context, &message))
+    }
+
+    pub fn operation_error(
+        &self,
+        context: OperationContext,
+        message: impl Into<String>,
+    ) -> OperationError {
+        let message = message.into();
+        map_operation_message(context, &message)
+    }
 }
 
 #[async_trait]
 impl ResourceManager<RobloxInputs, RobloxOutputs> for RobloxResourceManager {
     async fn get_create_price(
         &self,
+        resource_id: &str,
         inputs: RobloxInputs,
         dependency_outputs: Vec<RobloxOutputs>,
-    ) -> Result<Option<u32>, String> {
-        ops::price::get_create_price(self, inputs, dependency_outputs).await
+    ) -> Result<Option<u32>, OperationError> {
+        ops::price::get_create_price(self, resource_id, inputs, dependency_outputs).await
     }
 
     async fn create(
         &self,
+        resource_id: &str,
         inputs: RobloxInputs,
         dependency_outputs: Vec<RobloxOutputs>,
         price: Option<u32>,
-    ) -> Result<RobloxOutputs, String> {
-        ops::create::create(self, inputs, dependency_outputs, price).await
+    ) -> Result<RobloxOutputs, OperationError> {
+        ops::create::create(self, resource_id, inputs, dependency_outputs, price).await
     }
 
     async fn get_update_price(
         &self,
+        _resource_id: &str,
         _inputs: RobloxInputs,
         _outputs: RobloxOutputs,
         _dependency_outputs: Vec<RobloxOutputs>,
-    ) -> Result<Option<u32>, String> {
+    ) -> Result<Option<u32>, OperationError> {
         Ok(None)
     }
 
     async fn update(
         &self,
+        resource_id: &str,
         inputs: RobloxInputs,
         outputs: RobloxOutputs,
         dependency_outputs: Vec<RobloxOutputs>,
         price: Option<u32>,
-    ) -> Result<RobloxOutputs, String> {
-        ops::update::update(self, inputs, outputs, dependency_outputs, price).await
+    ) -> Result<RobloxOutputs, OperationError> {
+        ops::update::update(
+            self,
+            resource_id,
+            inputs,
+            outputs,
+            dependency_outputs,
+            price,
+        )
+        .await
     }
 
     async fn delete(
         &self,
+        resource_id: &str,
         outputs: RobloxOutputs,
         dependency_outputs: Vec<RobloxOutputs>,
-    ) -> Result<(), String> {
-        ops::delete::delete(self, outputs, dependency_outputs).await
+    ) -> Result<(), OperationError> {
+        ops::delete::delete(self, resource_id, outputs, dependency_outputs).await
+    }
+}
+
+fn resource_type_for_inputs(inputs: &RobloxInputs) -> &'static str {
+    match inputs {
+        RobloxInputs::Experience(_) => "Experience",
+        RobloxInputs::ExperienceConfiguration(_) => "ExperienceConfiguration",
+        RobloxInputs::ExperienceActivation(_) => "ExperienceActivation",
+        RobloxInputs::ExperienceIcon(_) => "ExperienceIcon",
+        RobloxInputs::ExperienceThumbnail(_) => "ExperienceThumbnail",
+        RobloxInputs::ExperienceThumbnailOrder => "ExperienceThumbnailOrder",
+        RobloxInputs::Place(_) => "Place",
+        RobloxInputs::PlaceFile(_) => "PlaceFile",
+        RobloxInputs::PlaceConfiguration(_) => "PlaceConfiguration",
+        RobloxInputs::SocialLink(_) => "SocialLink",
+        RobloxInputs::Product(_) => "Product",
+        RobloxInputs::ProductIcon(_) => "ProductIcon",
+        RobloxInputs::Pass(_) => "Pass",
+        RobloxInputs::Badge(_) => "Badge",
+        RobloxInputs::BadgeIcon(_) => "BadgeIcon",
+        RobloxInputs::ImageAsset(_) => "ImageAsset",
+        RobloxInputs::AudioAsset(_) => "AudioAsset",
+        RobloxInputs::AssetAlias(_) => "AssetAlias",
+        RobloxInputs::SpatialVoice(_) => "SpatialVoice",
+        RobloxInputs::Notification(_) => "Notification",
+    }
+}
+
+fn resource_type_for_outputs(outputs: &RobloxOutputs) -> &'static str {
+    match outputs {
+        RobloxOutputs::Experience(_) => "Experience",
+        RobloxOutputs::ExperienceConfiguration => "ExperienceConfiguration",
+        RobloxOutputs::ExperienceActivation => "ExperienceActivation",
+        RobloxOutputs::ExperienceIcon(_) => "ExperienceIcon",
+        RobloxOutputs::ExperienceThumbnail(_) => "ExperienceThumbnail",
+        RobloxOutputs::ExperienceThumbnailOrder => "ExperienceThumbnailOrder",
+        RobloxOutputs::Place(_) => "Place",
+        RobloxOutputs::PlaceFile(_) => "PlaceFile",
+        RobloxOutputs::PlaceConfiguration => "PlaceConfiguration",
+        RobloxOutputs::SocialLink(_) => "SocialLink",
+        RobloxOutputs::Product(_) => "Product",
+        RobloxOutputs::ProductIcon(_) => "ProductIcon",
+        RobloxOutputs::Pass(_) => "Pass",
+        RobloxOutputs::Badge(_) => "Badge",
+        RobloxOutputs::BadgeIcon(_) => "BadgeIcon",
+        RobloxOutputs::ImageAsset(_) => "ImageAsset",
+        RobloxOutputs::AudioAsset(_) => "AudioAsset",
+        RobloxOutputs::AssetAlias(_) => "AssetAlias",
+        RobloxOutputs::SpatialVoice => "SpatialVoice",
+        RobloxOutputs::Notification(_) => "Notification",
+    }
+}
+
+fn file_path_for_inputs(inputs: &RobloxInputs) -> Option<String> {
+    match inputs {
+        RobloxInputs::ExperienceIcon(file)
+        | RobloxInputs::ExperienceThumbnail(file)
+        | RobloxInputs::PlaceFile(file)
+        | RobloxInputs::ProductIcon(file)
+        | RobloxInputs::BadgeIcon(file) => Some(file.file_path.clone()),
+        RobloxInputs::Pass(inputs) => Some(inputs.icon_file_path.clone()),
+        RobloxInputs::Badge(inputs) => Some(inputs.icon_file_path.clone()),
+        RobloxInputs::ImageAsset(file) | RobloxInputs::AudioAsset(file) => {
+            Some(file.file_path.clone())
+        }
+        _ => None,
+    }
+}
+
+fn creator_target_for_inputs(inputs: &RobloxInputs) -> Option<String> {
+    match inputs {
+        RobloxInputs::Experience(inputs) => inputs
+            .group_id
+            .map(|group_id| format!("group:{}", group_id)),
+        RobloxInputs::ImageAsset(inputs) | RobloxInputs::AudioAsset(inputs) => inputs
+            .group_id
+            .map(|group_id| format!("group:{}", group_id)),
+        _ => None,
+    }
+}
+
+fn auth_model_for_inputs(mgr: &RobloxResourceManager, inputs: &RobloxInputs) -> &'static str {
+    match inputs {
+        RobloxInputs::PlaceFile(_) => {
+            if mgr.has_open_cloud_api_key() {
+                "open-cloud"
+            } else {
+                "missing-open-cloud"
+            }
+        }
+        RobloxInputs::ImageAsset(_) => {
+            if mgr.has_open_cloud_api_key() {
+                "hybrid"
+            } else {
+                "cookie-session"
+            }
+        }
+        _ => "cookie-session",
+    }
+}
+
+fn auth_model_for_outputs(mgr: &RobloxResourceManager, outputs: &RobloxOutputs) -> &'static str {
+    match outputs {
+        RobloxOutputs::PlaceFile(_) => {
+            if mgr.has_open_cloud_api_key() {
+                "open-cloud"
+            } else {
+                "missing-open-cloud"
+            }
+        }
+        _ => "cookie-session",
     }
 }

--- a/rbx_lithos/src/roblox_resource_manager/ops/create.rs
+++ b/rbx_lithos/src/roblox_resource_manager/ops/create.rs
@@ -29,6 +29,7 @@ use rbxcloud::rbx::{
 };
 use yansi::Paint;
 
+use crate::diagnostics::{OperationAction, OperationError};
 use crate::resource_graph::{all_outputs, optional_output, single_output};
 
 use super::super::{
@@ -42,18 +43,41 @@ use super::super::{
     RobloxResourceManager,
 };
 
+macro_rules! api_call {
+    ($mgr:expr, $context:expr, $endpoint:expr, $call:expr) => {{
+        $mgr.wrap_api_result($context.clone().with_endpoint($endpoint), ($call).await)?
+    }};
+}
+
+macro_rules! string_call {
+    ($mgr:expr, $context:expr, $endpoint:expr, $call:expr) => {{
+        $mgr.wrap_message_result(
+            $context.clone().with_endpoint($endpoint),
+            ($call).await.map_err(|error| error.to_string()),
+        )?
+    }};
+}
+
 pub(in crate::roblox_resource_manager) async fn create(
     mgr: &RobloxResourceManager,
+    resource_id: &str,
     inputs: RobloxInputs,
     dependency_outputs: Vec<RobloxOutputs>,
     price: Option<u32>,
-) -> Result<RobloxOutputs, String> {
+) -> Result<RobloxOutputs, OperationError> {
+    let context = mgr.context_for_inputs(OperationAction::Create, resource_id, &inputs);
+
     match inputs {
         RobloxInputs::Experience(inputs) => {
             let CreateExperienceResponse {
                 universe_id,
                 root_place_id,
-            } = mgr.roblox_api.create_experience(inputs.group_id).await?;
+            } = api_call!(
+                mgr,
+                context,
+                "create_experience",
+                mgr.roblox_api.create_experience(inputs.group_id)
+            );
 
             Ok(RobloxOutputs::Experience(ExperienceOutputs {
                 asset_id: universe_id,
@@ -63,28 +87,38 @@ pub(in crate::roblox_resource_manager) async fn create(
         RobloxInputs::ExperienceConfiguration(inputs) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            mgr.roblox_api
-                .configure_experience(experience.asset_id, &inputs)
-                .await?;
+            api_call!(
+                mgr,
+                context,
+                "configure_experience",
+                mgr.roblox_api
+                    .configure_experience(experience.asset_id, &inputs)
+            );
 
             Ok(RobloxOutputs::ExperienceConfiguration)
         }
         RobloxInputs::ExperienceActivation(inputs) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            mgr.roblox_api
-                .set_experience_active(experience.asset_id, inputs.is_active)
-                .await?;
+            api_call!(
+                mgr,
+                context,
+                "set_experience_active",
+                mgr.roblox_api
+                    .set_experience_active(experience.asset_id, inputs.is_active)
+            );
 
             Ok(RobloxOutputs::ExperienceActivation)
         }
         RobloxInputs::ExperienceIcon(inputs) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            let UploadImageResponse { target_id } = mgr
-                .roblox_api
-                .upload_icon(experience.asset_id, mgr.get_path(inputs.file_path))
-                .await?;
+            let UploadImageResponse { target_id } = mgr.wrap_api_result(
+                context.clone().with_endpoint("upload_icon"),
+                mgr.roblox_api
+                    .upload_icon(experience.asset_id, mgr.get_path(inputs.file_path))
+                    .await,
+            )?;
 
             Ok(RobloxOutputs::ExperienceIcon(AssetOutputs {
                 asset_id: target_id,
@@ -93,10 +127,12 @@ pub(in crate::roblox_resource_manager) async fn create(
         RobloxInputs::ExperienceThumbnail(inputs) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            let UploadImageResponse { target_id } = mgr
-                .roblox_api
-                .upload_thumbnail(experience.asset_id, mgr.get_path(inputs.file_path))
-                .await?;
+            let UploadImageResponse { target_id } = mgr.wrap_api_result(
+                context.clone().with_endpoint("upload_thumbnail"),
+                mgr.roblox_api
+                    .upload_thumbnail(experience.asset_id, mgr.get_path(inputs.file_path))
+                    .await,
+            )?;
 
             Ok(RobloxOutputs::ExperienceThumbnail(AssetOutputs {
                 asset_id: target_id,
@@ -106,12 +142,15 @@ pub(in crate::roblox_resource_manager) async fn create(
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
             let thumbnails = all_outputs!(dependency_outputs, RobloxOutputs::ExperienceThumbnail);
 
-            mgr.roblox_api
-                .set_experience_thumbnail_order(
+            api_call!(
+                mgr,
+                context,
+                "set_experience_thumbnail_order",
+                mgr.roblox_api.set_experience_thumbnail_order(
                     experience.asset_id,
                     &thumbnails.iter().map(|t| t.asset_id).collect::<Vec<_>>(),
                 )
-                .await?;
+            );
 
             Ok(RobloxOutputs::ExperienceThumbnailOrder)
         }
@@ -121,10 +160,13 @@ pub(in crate::roblox_resource_manager) async fn create(
             let asset_id = if inputs.is_start {
                 experience.start_place_id
             } else {
-                mgr.roblox_api
-                    .create_place(experience.asset_id)
-                    .await?
-                    .place_id
+                api_call!(
+                    mgr,
+                    context,
+                    "create_place",
+                    mgr.roblox_api.create_place(experience.asset_id)
+                )
+                .place_id
             };
 
             Ok(RobloxOutputs::Place(AssetOutputs { asset_id }))
@@ -134,56 +176,71 @@ pub(in crate::roblox_resource_manager) async fn create(
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
             if let Some(roblox_cloud) = &mgr.roblox_cloud {
-                let response = roblox_cloud
-                    .experience(UniverseId(experience.asset_id), PlaceId(place.asset_id))
-                    .publish(
-                        &mgr.get_path(inputs.file_path)
-                            .into_os_string()
-                            .into_string()
-                            .unwrap(),
-                        PublishVersionType::Published,
-                    )
-                    .await
-                    .map_err(|e| e.to_string())?;
+                let response = string_call!(
+                    mgr,
+                    context,
+                    "publish_place_version",
+                    roblox_cloud
+                        .experience(UniverseId(experience.asset_id), PlaceId(place.asset_id))
+                        .publish(
+                            &mgr.get_path(inputs.file_path)
+                                .into_os_string()
+                                .into_string()
+                                .unwrap(),
+                            PublishVersionType::Published,
+                        )
+                );
 
                 Ok(RobloxOutputs::PlaceFile(PlaceFileOutputs {
                     version: response.version_number,
                 }))
             } else {
-                Err("Place uploads require Open Cloud authentication. Find out more here: https://mantledeploy.vercel.app/docs/authentication#roblox-open-cloud-api-key".to_string())
+                Err(mgr.operation_error(
+                    context,
+                    "Place uploads require Open Cloud authentication. Find out more here: https://mantledeploy.vercel.app/docs/authentication#roblox-open-cloud-api-key",
+                ))
             }
         }
         RobloxInputs::PlaceConfiguration(inputs) => {
             let place = single_output!(dependency_outputs, RobloxOutputs::Place);
 
-            mgr.roblox_api
-                .configure_place(place.asset_id, &inputs)
-                .await?;
+            api_call!(
+                mgr,
+                context,
+                "configure_place",
+                mgr.roblox_api.configure_place(place.asset_id, &inputs)
+            );
 
             Ok(RobloxOutputs::PlaceConfiguration)
         }
         RobloxInputs::SocialLink(inputs) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            let CreateSocialLinkResponse { id } = mgr
-                .roblox_api
-                .create_social_link(
-                    experience.asset_id,
-                    inputs.title,
-                    inputs.url,
-                    inputs.link_type,
-                )
-                .await?;
+            let CreateSocialLinkResponse { id } = mgr.wrap_api_result(
+                context.clone().with_endpoint("create_social_link"),
+                mgr.roblox_api
+                    .create_social_link(
+                        experience.asset_id,
+                        inputs.title,
+                        inputs.url,
+                        inputs.link_type,
+                    )
+                    .await,
+            )?;
 
             Ok(RobloxOutputs::SocialLink(AssetOutputs { asset_id: id }))
         }
         RobloxInputs::ProductIcon(inputs) => {
             let product = single_output!(dependency_outputs, RobloxOutputs::Product);
 
-            let CreateDeveloperProductIconResponse { image_asset_id } = mgr
-                .roblox_api
-                .create_developer_product_icon(product.asset_id, mgr.get_path(inputs.file_path))
-                .await?;
+            let CreateDeveloperProductIconResponse { image_asset_id } = mgr.wrap_api_result(
+                context
+                    .clone()
+                    .with_endpoint("create_developer_product_icon"),
+                mgr.roblox_api
+                    .create_developer_product_icon(product.asset_id, mgr.get_path(inputs.file_path))
+                    .await,
+            )?;
 
             Ok(RobloxOutputs::ProductIcon(AssetOutputs {
                 asset_id: image_asset_id,
@@ -192,18 +249,22 @@ pub(in crate::roblox_resource_manager) async fn create(
         RobloxInputs::Product(inputs) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            let CreateDeveloperProductResponse { id } = mgr
-                .roblox_api
-                .create_developer_product(
-                    experience.asset_id,
-                    inputs.name,
-                    inputs.price,
-                    inputs.description,
-                )
-                .await?;
+            let CreateDeveloperProductResponse { id } = mgr.wrap_api_result(
+                context.clone().with_endpoint("create_developer_product"),
+                mgr.roblox_api
+                    .create_developer_product(
+                        experience.asset_id,
+                        inputs.name,
+                        inputs.price,
+                        inputs.description,
+                    )
+                    .await,
+            )?;
 
-            let GetDeveloperProductResponse { id: product_id } =
-                mgr.roblox_api.get_developer_product(id).await?;
+            let GetDeveloperProductResponse { id: product_id } = mgr.wrap_api_result(
+                context.clone().with_endpoint("get_developer_product"),
+                mgr.roblox_api.get_developer_product(id).await,
+            )?;
 
             Ok(RobloxOutputs::Product(ProductOutputs {
                 asset_id: product_id,
@@ -213,28 +274,32 @@ pub(in crate::roblox_resource_manager) async fn create(
         RobloxInputs::Pass(inputs) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            let CreateGamePassResponse { game_pass_id } = mgr
-                .roblox_api
-                .create_game_pass(
-                    experience.asset_id,
-                    inputs.name.clone(),
-                    inputs.description.clone(),
-                    mgr.get_path(inputs.icon_file_path),
-                )
-                .await?;
+            let CreateGamePassResponse { game_pass_id } = mgr.wrap_api_result(
+                context.clone().with_endpoint("create_game_pass"),
+                mgr.roblox_api
+                    .create_game_pass(
+                        experience.asset_id,
+                        inputs.name.clone(),
+                        inputs.description.clone(),
+                        mgr.get_path(inputs.icon_file_path),
+                    )
+                    .await,
+            )?;
             let GetGamePassResponse {
                 icon_image_asset_id,
                 ..
-            } = mgr
-                .roblox_api
-                .update_game_pass(
-                    game_pass_id,
-                    inputs.name,
-                    inputs.description,
-                    inputs.price,
-                    None,
-                )
-                .await?;
+            } = mgr.wrap_api_result(
+                context.clone().with_endpoint("update_game_pass"),
+                mgr.roblox_api
+                    .update_game_pass(
+                        game_pass_id,
+                        inputs.name,
+                        inputs.description,
+                        inputs.price,
+                        None,
+                    )
+                    .await,
+            )?;
 
             Ok(RobloxOutputs::Pass(PassOutputs {
                 asset_id: game_pass_id,
@@ -244,17 +309,19 @@ pub(in crate::roblox_resource_manager) async fn create(
         RobloxInputs::Badge(inputs) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            let CreateBadgeResponse { id, icon_image_id } = mgr
-                .roblox_api
-                .create_badge(
-                    experience.asset_id,
-                    inputs.name,
-                    inputs.description,
-                    mgr.get_path(inputs.icon_file_path),
-                    mgr.payment_source.clone(),
-                    price.unwrap_or(0),
-                )
-                .await?;
+            let CreateBadgeResponse { id, icon_image_id } = mgr.wrap_api_result(
+                context.clone().with_endpoint("create_badge"),
+                mgr.roblox_api
+                    .create_badge(
+                        experience.asset_id,
+                        inputs.name,
+                        inputs.description,
+                        mgr.get_path(inputs.icon_file_path),
+                        mgr.payment_source.clone(),
+                        price.unwrap_or(0),
+                    )
+                    .await,
+            )?;
 
             Ok(RobloxOutputs::Badge(AssetWithInitialIconOutputs {
                 asset_id: id,
@@ -273,10 +340,12 @@ pub(in crate::roblox_resource_manager) async fn create(
                 Some(group_id) => Creator::GroupId(group_id.to_string()),
                 None => Creator::UserId(mgr.user.id.to_string()),
             };
-            let asset_id = mgr
-                .roblox_api
-                .create_image_asset(mgr.get_path(&inputs.file_path), creator)
-                .await?;
+            let asset_id = mgr.wrap_api_result(
+                context.clone().with_endpoint("create_image_asset"),
+                mgr.roblox_api
+                    .create_image_asset(mgr.get_path(&inputs.file_path), creator)
+                    .await,
+            )?;
             Ok(RobloxOutputs::ImageAsset(ImageAssetOutputs {
                 asset_id,
                 // TODO: This breaks archiving assets.
@@ -289,14 +358,21 @@ pub(in crate::roblox_resource_manager) async fn create(
                 capacity,
                 expiration_time,
                 duration,
-            } = mgr
-                .roblox_api
-                .get_create_asset_quota(AssetTypeId::Audio)
-                .await?;
+            } = mgr.wrap_api_result(
+                context.clone().with_endpoint("get_create_asset_quota"),
+                mgr.roblox_api
+                    .get_create_asset_quota(AssetTypeId::Audio)
+                    .await,
+            )?;
 
             let quota_reset = format_quota_reset(match expiration_time {
                 Some(ref x) => DateTime::parse_from_rfc3339(x)
-                    .map_err(|e| format!("Unable to parse expiration_time: {}", e))?
+                    .map_err(|e| {
+                        mgr.operation_error(
+                            context.clone().with_endpoint("get_create_asset_quota"),
+                            format!("Unable to parse expiration_time: {}", e),
+                        )
+                    })?
                     .with_timezone(&Utc),
                 None => {
                     Utc::now()
@@ -315,20 +391,25 @@ pub(in crate::roblox_resource_manager) async fn create(
                     quota_reset
                 )));
 
-                let CreateAudioAssetResponse { id } = mgr
-                    .roblox_api
-                    .create_audio_asset(
-                        mgr.get_path(inputs.file_path),
-                        inputs.group_id,
-                        mgr.payment_source.clone(),
-                    )
-                    .await?;
+                let CreateAudioAssetResponse { id } = mgr.wrap_api_result(
+                    context.clone().with_endpoint("create_audio_asset"),
+                    mgr.roblox_api
+                        .create_audio_asset(
+                            mgr.get_path(inputs.file_path),
+                            inputs.group_id,
+                            mgr.payment_source.clone(),
+                        )
+                        .await,
+                )?;
 
                 Ok(RobloxOutputs::AudioAsset(AssetOutputs { asset_id: id }))
             } else {
-                Err(format!(
-                    "You have reached your audio upload quota. Your quota will reset in {}.",
-                    quota_reset
+                Err(mgr.operation_error(
+                    context,
+                    format!(
+                        "You have reached your audio upload quota. Your quota will reset in {}.",
+                        quota_reset
+                    ),
                 ))
             }
         }
@@ -343,13 +424,23 @@ pub(in crate::roblox_resource_manager) async fn create(
                 _ => panic!("Missing expected output."),
             };
 
-            mgr.roblox_api
-                .create_asset_alias(experience.asset_id, asset_id, inputs.name.clone())
-                .await?;
+            api_call!(
+                mgr,
+                context,
+                "create_asset_alias",
+                mgr.roblox_api.create_asset_alias(
+                    experience.asset_id,
+                    asset_id,
+                    inputs.name.clone()
+                )
+            );
 
             if audio_asset.is_some() {
-                mgr.roblox_api
-                    .grant_asset_permissions(
+                api_call!(
+                    mgr,
+                    context,
+                    "grant_asset_permissions",
+                    mgr.roblox_api.grant_asset_permissions(
                         asset_id,
                         GrantAssetPermissionsRequestRequest {
                             subject_id: experience.asset_id,
@@ -357,7 +448,7 @@ pub(in crate::roblox_resource_manager) async fn create(
                             action: GrantAssetPermissionRequestAction::Use,
                         },
                     )
-                    .await?;
+                );
             }
 
             Ok(RobloxOutputs::AssetAlias(AssetAliasOutputs {
@@ -367,24 +458,29 @@ pub(in crate::roblox_resource_manager) async fn create(
         RobloxInputs::SpatialVoice(inputs) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            mgr.roblox_api
-                .update_spatial_voice_settings(
+            api_call!(
+                mgr,
+                context,
+                "update_spatial_voice_settings",
+                mgr.roblox_api.update_spatial_voice_settings(
                     experience.asset_id,
                     UpdateSpatialVoiceSettingsRequest {
                         opt_in: inputs.enabled,
                     },
                 )
-                .await?;
+            );
 
             Ok(RobloxOutputs::SpatialVoice)
         }
         RobloxInputs::Notification(inputs) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            let CreateNotificationResponse { id } = mgr
-                .roblox_api
-                .create_notification(experience.asset_id, inputs.name, inputs.content)
-                .await?;
+            let CreateNotificationResponse { id } = mgr.wrap_api_result(
+                context.clone().with_endpoint("create_notification"),
+                mgr.roblox_api
+                    .create_notification(experience.asset_id, inputs.name, inputs.content)
+                    .await,
+            )?;
 
             Ok(RobloxOutputs::Notification(NotificationOutputs { id }))
         }

--- a/rbx_lithos/src/roblox_resource_manager/ops/delete.rs
+++ b/rbx_lithos/src/roblox_resource_manager/ops/delete.rs
@@ -11,63 +11,97 @@ use rbx_api::{
     spatial_voice::models::UpdateSpatialVoiceSettingsRequest,
 };
 
+use crate::diagnostics::{OperationAction, OperationError};
 use crate::resource_graph::{all_outputs, single_output};
 
 use super::super::{outputs::RobloxOutputs, RobloxResourceManager};
 
+macro_rules! api_call {
+    ($mgr:expr, $context:expr, $endpoint:expr, $call:expr) => {{
+        $mgr.wrap_api_result($context.clone().with_endpoint($endpoint), ($call).await)?
+    }};
+}
+
 // TODO: Do we need inputs?
 pub(in crate::roblox_resource_manager) async fn delete(
     mgr: &RobloxResourceManager,
+    resource_id: &str,
     outputs: RobloxOutputs,
     dependency_outputs: Vec<RobloxOutputs>,
-) -> Result<(), String> {
+) -> Result<(), OperationError> {
+    let context = mgr.context_for_outputs(OperationAction::Delete, resource_id, &outputs);
+
     match outputs {
         RobloxOutputs::Experience(outputs) => {
             let model = ExperienceConfigurationModel {
                 is_archived: true,
                 ..Default::default()
             };
-            mgr.roblox_api
-                .configure_experience(outputs.asset_id, &model)
-                .await?;
+            api_call!(
+                mgr,
+                context,
+                "configure_experience",
+                mgr.roblox_api
+                    .configure_experience(outputs.asset_id, &model)
+            );
         }
         RobloxOutputs::ExperienceConfiguration => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
             let model = ExperienceConfigurationModel::default();
-            mgr.roblox_api
-                .configure_experience(experience.asset_id, &model)
-                .await?;
+            api_call!(
+                mgr,
+                context,
+                "configure_experience",
+                mgr.roblox_api
+                    .configure_experience(experience.asset_id, &model)
+            );
         }
         RobloxOutputs::ExperienceActivation => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            mgr.roblox_api
-                .set_experience_active(experience.asset_id, false)
-                .await?;
+            api_call!(
+                mgr,
+                context,
+                "set_experience_active",
+                mgr.roblox_api
+                    .set_experience_active(experience.asset_id, false)
+            );
         }
         RobloxOutputs::ExperienceIcon(outputs) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            mgr.roblox_api
-                .remove_experience_icon(experience.start_place_id, outputs.asset_id)
-                .await?;
+            api_call!(
+                mgr,
+                context,
+                "remove_experience_icon",
+                mgr.roblox_api
+                    .remove_experience_icon(experience.start_place_id, outputs.asset_id)
+            );
         }
         RobloxOutputs::ExperienceThumbnail(outputs) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            mgr.roblox_api
-                .delete_experience_thumbnail(experience.asset_id, outputs.asset_id)
-                .await?;
+            api_call!(
+                mgr,
+                context,
+                "delete_experience_thumbnail",
+                mgr.roblox_api
+                    .delete_experience_thumbnail(experience.asset_id, outputs.asset_id)
+            );
         }
         RobloxOutputs::ExperienceThumbnailOrder => {}
         RobloxOutputs::Place(outputs) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
             if outputs.asset_id != experience.start_place_id {
-                mgr.roblox_api
-                    .remove_place_from_experience(experience.asset_id, outputs.asset_id)
-                    .await?;
+                api_call!(
+                    mgr,
+                    context,
+                    "remove_place_from_experience",
+                    mgr.roblox_api
+                        .remove_place_from_experience(experience.asset_id, outputs.asset_id)
+                );
             }
         }
         RobloxOutputs::PlaceFile(_) => {}
@@ -75,85 +109,123 @@ pub(in crate::roblox_resource_manager) async fn delete(
             let place = single_output!(dependency_outputs, RobloxOutputs::Place);
 
             let model = PlaceConfigurationModel::default();
-            mgr.roblox_api
-                .configure_place(place.asset_id, &model)
-                .await?;
+            api_call!(
+                mgr,
+                context,
+                "configure_place",
+                mgr.roblox_api.configure_place(place.asset_id, &model)
+            );
         }
         RobloxOutputs::SocialLink(outputs) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            mgr.roblox_api
-                .delete_social_link(experience.asset_id, outputs.asset_id)
-                .await?;
+            api_call!(
+                mgr,
+                context,
+                "delete_social_link",
+                mgr.roblox_api
+                    .delete_social_link(experience.asset_id, outputs.asset_id)
+            );
         }
         RobloxOutputs::ProductIcon(_) => {}
         RobloxOutputs::Product(outputs) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
             let utc = Utc::now();
-            mgr.roblox_api
-                .update_developer_product(
+            api_call!(
+                mgr,
+                context,
+                "update_developer_product",
+                mgr.roblox_api.update_developer_product(
                     experience.asset_id,
                     outputs.asset_id,
                     format!("zzz_DEPRECATED({})", utc.format("%F %T%.f")),
                     0,
                     "".to_owned(),
                 )
-                .await?;
+            );
         }
         RobloxOutputs::Pass(outputs) => {
             let utc = Utc::now();
-            mgr.roblox_api
-                .update_game_pass(
+            api_call!(
+                mgr,
+                context,
+                "update_game_pass",
+                mgr.roblox_api.update_game_pass(
                     outputs.asset_id,
                     format!("zzz_DEPRECATED({})", utc.format("%F %T%.f")),
                     "".to_owned(),
                     None,
                     None,
                 )
-                .await?;
+            );
         }
         RobloxOutputs::Badge(outputs) => {
             let utc = Utc::now();
-            mgr.roblox_api
-                .update_badge(
+            api_call!(
+                mgr,
+                context,
+                "update_badge",
+                mgr.roblox_api.update_badge(
                     outputs.asset_id,
                     format!("zzz_DEPRECATED({})", utc.format("%F %T%.f")),
                     "".to_owned(),
                     false,
                 )
-                .await?;
+            );
         }
         RobloxOutputs::BadgeIcon(_) => {}
         RobloxOutputs::ImageAsset(outputs) => {
             // TODO: Can we make this not optional and just not import the image asset? Maybe?
             if let Some(decal_asset_id) = outputs.decal_asset_id {
-                mgr.roblox_api.archive_asset(decal_asset_id).await?;
+                api_call!(
+                    mgr,
+                    context,
+                    "archive_asset",
+                    mgr.roblox_api.archive_asset(decal_asset_id)
+                );
             }
             // TODO: if no decal ID is available use Open Cloud API to archive. rbx_cloud currently doesn't support this API
         }
         RobloxOutputs::AudioAsset(outputs) => {
-            mgr.roblox_api.archive_asset(outputs.asset_id).await?;
+            api_call!(
+                mgr,
+                context,
+                "archive_asset",
+                mgr.roblox_api.archive_asset(outputs.asset_id)
+            );
         }
         RobloxOutputs::AssetAlias(outputs) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            mgr.roblox_api
-                .delete_asset_alias(experience.asset_id, outputs.name)
-                .await?;
+            api_call!(
+                mgr,
+                context,
+                "delete_asset_alias",
+                mgr.roblox_api
+                    .delete_asset_alias(experience.asset_id, outputs.name)
+            );
         }
         RobloxOutputs::SpatialVoice => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            mgr.roblox_api
-                .update_spatial_voice_settings(
+            api_call!(
+                mgr,
+                context,
+                "update_spatial_voice_settings",
+                mgr.roblox_api.update_spatial_voice_settings(
                     experience.asset_id,
                     UpdateSpatialVoiceSettingsRequest { opt_in: false },
                 )
-                .await?;
+            );
         }
         RobloxOutputs::Notification(outputs) => {
-            mgr.roblox_api.archive_notification(outputs.id).await?;
+            api_call!(
+                mgr,
+                context,
+                "archive_notification",
+                mgr.roblox_api.archive_notification(outputs.id)
+            );
         }
     }
     Ok(())

--- a/rbx_lithos/src/roblox_resource_manager/ops/price.rs
+++ b/rbx_lithos/src/roblox_resource_manager/ops/price.rs
@@ -3,6 +3,7 @@
 use chrono::{Duration, Timelike, Utc};
 use yansi::Paint;
 
+use crate::diagnostics::{OperationAction, OperationError};
 use crate::resource_graph::{all_outputs, single_output};
 
 use super::super::{
@@ -11,16 +12,21 @@ use super::super::{
 
 pub(in crate::roblox_resource_manager) async fn get_create_price(
     mgr: &RobloxResourceManager,
+    resource_id: &str,
     inputs: RobloxInputs,
     dependency_outputs: Vec<RobloxOutputs>,
-) -> Result<Option<u32>, String> {
+) -> Result<Option<u32>, OperationError> {
+    let context = mgr.context_for_inputs(OperationAction::Create, resource_id, &inputs);
+
     match inputs {
         RobloxInputs::Badge(_) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
-            let free_quota = mgr
-                .roblox_api
-                .get_create_badge_free_quota(experience.asset_id)
-                .await?;
+            let free_quota = mgr.wrap_api_result(
+                context.with_endpoint("badge-free-quota"),
+                mgr.roblox_api
+                    .get_create_badge_free_quota(experience.asset_id)
+                    .await,
+            )?;
 
             let quota_reset = format_quota_reset(
                 (Utc::now() + Duration::days(1))

--- a/rbx_lithos/src/roblox_resource_manager/ops/update.rs
+++ b/rbx_lithos/src/roblox_resource_manager/ops/update.rs
@@ -14,6 +14,7 @@ use rbx_api::{
     spatial_voice::models::UpdateSpatialVoiceSettingsRequest,
 };
 
+use crate::diagnostics::{OperationAction, OperationError};
 use crate::resource_graph::{all_outputs, optional_output, single_output};
 
 use super::super::{
@@ -22,75 +23,90 @@ use super::super::{
     RobloxResourceManager,
 };
 
+macro_rules! api_call {
+    ($mgr:expr, $context:expr, $endpoint:expr, $call:expr) => {{
+        $mgr.wrap_api_result($context.clone().with_endpoint($endpoint), ($call).await)?
+    }};
+}
+
 // TODO: Consider moving `outputs` into `dependency_outputs`.
 pub(in crate::roblox_resource_manager) async fn update(
     mgr: &RobloxResourceManager,
+    resource_id: &str,
     inputs: RobloxInputs,
     outputs: RobloxOutputs,
     dependency_outputs: Vec<RobloxOutputs>,
     price: Option<u32>,
-) -> Result<RobloxOutputs, String> {
+) -> Result<RobloxOutputs, OperationError> {
+    let context = mgr.context_for_inputs(OperationAction::Update, resource_id, &inputs);
+
     match (inputs.clone(), outputs.clone()) {
         (RobloxInputs::Experience(_), RobloxOutputs::Experience(_)) => {
-            super::delete::delete(mgr, outputs, dependency_outputs.clone()).await?;
-            super::create::create(mgr, inputs, dependency_outputs, price).await
+            super::delete::delete(mgr, resource_id, outputs, dependency_outputs.clone()).await?;
+            super::create::create(mgr, resource_id, inputs, dependency_outputs, price).await
         }
         (RobloxInputs::ExperienceConfiguration(_), RobloxOutputs::ExperienceConfiguration) => {
-            super::create::create(mgr, inputs, dependency_outputs, price).await
+            super::create::create(mgr, resource_id, inputs, dependency_outputs, price).await
         }
         (RobloxInputs::ExperienceActivation(_), RobloxOutputs::ExperienceActivation) => {
-            super::create::create(mgr, inputs, dependency_outputs, price).await
+            super::create::create(mgr, resource_id, inputs, dependency_outputs, price).await
         }
         (RobloxInputs::ExperienceIcon(_), RobloxOutputs::ExperienceIcon(_)) => {
-            super::create::create(mgr, inputs, dependency_outputs, price).await
+            super::create::create(mgr, resource_id, inputs, dependency_outputs, price).await
         }
         (RobloxInputs::ExperienceThumbnail(_), RobloxOutputs::ExperienceThumbnail(_)) => {
-            super::delete::delete(mgr, outputs, dependency_outputs.clone()).await?;
-            super::create::create(mgr, inputs, dependency_outputs, price).await
+            super::delete::delete(mgr, resource_id, outputs, dependency_outputs.clone()).await?;
+            super::create::create(mgr, resource_id, inputs, dependency_outputs, price).await
         }
         (RobloxInputs::ExperienceThumbnailOrder, RobloxOutputs::ExperienceThumbnailOrder) => {
-            super::create::create(mgr, inputs, dependency_outputs, price).await
+            super::create::create(mgr, resource_id, inputs, dependency_outputs, price).await
         }
         // TODO: is this correct?
         (RobloxInputs::Place(_), RobloxOutputs::Place(_)) => {
-            super::create::create(mgr, inputs, dependency_outputs, price).await
+            super::create::create(mgr, resource_id, inputs, dependency_outputs, price).await
         }
         (RobloxInputs::PlaceFile(_), RobloxOutputs::PlaceFile(_)) => {
-            super::create::create(mgr, inputs, dependency_outputs, price).await
+            super::create::create(mgr, resource_id, inputs, dependency_outputs, price).await
         }
         (RobloxInputs::PlaceConfiguration(_), RobloxOutputs::PlaceConfiguration) => {
-            super::create::create(mgr, inputs, dependency_outputs, price).await
+            super::create::create(mgr, resource_id, inputs, dependency_outputs, price).await
         }
         (RobloxInputs::SocialLink(inputs), RobloxOutputs::SocialLink(outputs)) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            mgr.roblox_api
-                .update_social_link(
+            api_call!(
+                mgr,
+                context,
+                "update_social_link",
+                mgr.roblox_api.update_social_link(
                     experience.asset_id,
                     outputs.asset_id,
                     inputs.title,
                     inputs.url,
                     inputs.link_type,
                 )
-                .await?;
+            );
 
             Ok(RobloxOutputs::SocialLink(outputs))
         }
         (RobloxInputs::ProductIcon(_), RobloxOutputs::ProductIcon(_)) => {
-            super::create::create(mgr, inputs, dependency_outputs, price).await
+            super::create::create(mgr, resource_id, inputs, dependency_outputs, price).await
         }
         (RobloxInputs::Product(inputs), RobloxOutputs::Product(outputs)) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            mgr.roblox_api
-                .update_developer_product(
+            api_call!(
+                mgr,
+                context,
+                "update_developer_product",
+                mgr.roblox_api.update_developer_product(
                     experience.asset_id,
                     outputs.asset_id,
                     inputs.name,
                     inputs.price,
                     inputs.description,
                 )
-                .await?;
+            );
 
             Ok(RobloxOutputs::Product(outputs))
         }
@@ -98,16 +114,18 @@ pub(in crate::roblox_resource_manager) async fn update(
             let GetGamePassResponse {
                 icon_image_asset_id,
                 ..
-            } = mgr
-                .roblox_api
-                .update_game_pass(
-                    outputs.asset_id,
-                    inputs.name,
-                    inputs.description,
-                    inputs.price,
-                    Some(mgr.get_path(inputs.icon_file_path)),
-                )
-                .await?;
+            } = mgr.wrap_api_result(
+                context.clone().with_endpoint("update_game_pass"),
+                mgr.roblox_api
+                    .update_game_pass(
+                        outputs.asset_id,
+                        inputs.name,
+                        inputs.description,
+                        inputs.price,
+                        Some(mgr.get_path(inputs.icon_file_path)),
+                    )
+                    .await,
+            )?;
 
             Ok(RobloxOutputs::Pass(PassOutputs {
                 asset_id: outputs.asset_id,
@@ -115,34 +133,39 @@ pub(in crate::roblox_resource_manager) async fn update(
             }))
         }
         (RobloxInputs::Badge(inputs), RobloxOutputs::Badge(outputs)) => {
-            mgr.roblox_api
-                .update_badge(
+            api_call!(
+                mgr,
+                context,
+                "update_badge",
+                mgr.roblox_api.update_badge(
                     outputs.asset_id,
                     inputs.name,
                     inputs.description,
                     inputs.enabled,
                 )
-                .await?;
+            );
 
             Ok(RobloxOutputs::Badge(outputs))
         }
         (RobloxInputs::BadgeIcon(inputs), RobloxOutputs::BadgeIcon(_)) => {
             let badge = single_output!(dependency_outputs, RobloxOutputs::Badge);
 
-            let UploadImageResponse { target_id } = mgr
-                .roblox_api
-                .update_badge_icon(badge.asset_id, mgr.get_path(inputs.file_path))
-                .await?;
+            let UploadImageResponse { target_id } = mgr.wrap_api_result(
+                context.clone().with_endpoint("update_badge_icon"),
+                mgr.roblox_api
+                    .update_badge_icon(badge.asset_id, mgr.get_path(inputs.file_path))
+                    .await,
+            )?;
 
             Ok(RobloxOutputs::BadgeIcon(AssetOutputs {
                 asset_id: target_id,
             }))
         }
         (RobloxInputs::ImageAsset(_), RobloxOutputs::ImageAsset(_)) => {
-            super::create::create(mgr, inputs, dependency_outputs, price).await
+            super::create::create(mgr, resource_id, inputs, dependency_outputs, price).await
         }
         (RobloxInputs::AudioAsset(_), RobloxOutputs::AudioAsset(_)) => {
-            super::create::create(mgr, inputs, dependency_outputs, price).await
+            super::create::create(mgr, resource_id, inputs, dependency_outputs, price).await
         }
         (RobloxInputs::AssetAlias(inputs), RobloxOutputs::AssetAlias(outputs)) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
@@ -155,18 +178,24 @@ pub(in crate::roblox_resource_manager) async fn update(
                 _ => panic!("Missing expected output."),
             };
 
-            mgr.roblox_api
-                .update_asset_alias(
+            api_call!(
+                mgr,
+                context,
+                "update_asset_alias",
+                mgr.roblox_api.update_asset_alias(
                     experience.asset_id,
                     asset_id,
                     outputs.name,
                     inputs.name.clone(),
                 )
-                .await?;
+            );
 
             if audio_asset.is_some() {
-                mgr.roblox_api
-                    .grant_asset_permissions(
+                api_call!(
+                    mgr,
+                    context,
+                    "grant_asset_permissions",
+                    mgr.roblox_api.grant_asset_permissions(
                         asset_id,
                         GrantAssetPermissionsRequestRequest {
                             subject_id: experience.asset_id,
@@ -174,7 +203,7 @@ pub(in crate::roblox_resource_manager) async fn update(
                             action: GrantAssetPermissionRequestAction::Use,
                         },
                     )
-                    .await?;
+                );
             }
 
             Ok(RobloxOutputs::AssetAlias(AssetAliasOutputs {
@@ -184,22 +213,29 @@ pub(in crate::roblox_resource_manager) async fn update(
         (RobloxInputs::SpatialVoice(inputs), RobloxOutputs::SpatialVoice) => {
             let experience = single_output!(dependency_outputs, RobloxOutputs::Experience);
 
-            mgr.roblox_api
-                .update_spatial_voice_settings(
+            api_call!(
+                mgr,
+                context,
+                "update_spatial_voice_settings",
+                mgr.roblox_api.update_spatial_voice_settings(
                     experience.asset_id,
                     UpdateSpatialVoiceSettingsRequest {
                         opt_in: inputs.enabled,
                     },
                 )
-                .await?;
+            );
 
             Ok(RobloxOutputs::SpatialVoice)
         }
         (RobloxInputs::Notification(inputs), RobloxOutputs::Notification(outputs)) => {
             let asset_id = outputs.id.clone();
-            mgr.roblox_api
-                .update_notification(asset_id, inputs.name, inputs.content)
-                .await?;
+            api_call!(
+                mgr,
+                context,
+                "update_notification",
+                mgr.roblox_api
+                    .update_notification(asset_id, inputs.name, inputs.content)
+            );
 
             Ok(RobloxOutputs::Notification(outputs))
         }

--- a/rbx_lithos/src/state/history.rs
+++ b/rbx_lithos/src/state/history.rs
@@ -1,0 +1,186 @@
+use crate::{
+    diagnostics::DeploymentDiagnostic,
+    resource_graph::{EvaluateError, ResourceGraph},
+    roblox_resource_manager::{RobloxInputs, RobloxOutputs, RobloxResource},
+};
+
+use super::v7::{
+    build_applied_journal, DeploymentJournalEntry, DeploymentJournalStatus, ResourceStateV7,
+};
+
+pub fn build_failure_journal(
+    baseline_graph: &ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs>,
+    resulting_graph: &ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs>,
+    error: &EvaluateError,
+) -> Vec<DeploymentJournalEntry> {
+    let mut journal = build_applied_journal(baseline_graph, resulting_graph);
+    journal.extend(error.failures.iter().map(|failure| {
+        DeploymentJournalEntry {
+            resource_id: failure.resource_id.clone(),
+            action: failure
+                .error
+                .diagnostics()
+                .first()
+                .and_then(|diagnostic| diagnostic.operation.as_ref())
+                .map(|operation| operation.action)
+                .unwrap_or(crate::diagnostics::OperationAction::Update),
+            status: DeploymentJournalStatus::Failed,
+            summary: failure.error.summary().to_owned(),
+            diagnostics: failure.error.diagnostics().to_vec(),
+        }
+    }));
+    journal
+}
+
+pub fn build_success_journal(
+    baseline_graph: &ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs>,
+    resulting_graph: &ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs>,
+) -> Vec<DeploymentJournalEntry> {
+    build_applied_journal(baseline_graph, resulting_graph)
+}
+
+pub fn rollback_snapshot(state: &ResourceStateV7, label: &str) -> Option<Vec<RobloxResource>> {
+    state
+        .latest_rollback_record(label)
+        .map(|record| record.baseline.clone())
+}
+
+pub fn latest_deployment_diagnostics(
+    state: &ResourceStateV7,
+    label: &str,
+) -> Vec<DeploymentDiagnostic> {
+    state
+        .latest_rollback_record(label)
+        .map(|record| {
+            record
+                .journal
+                .iter()
+                .flat_map(|entry| entry.diagnostics.clone())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::{
+        diagnostics::{DeploymentDiagnostic, DiagnosticCategory, OperationAction, OperationError},
+        resource_graph::{
+            EvaluateError, EvaluateResults, Resource, ResourceFailure, ResourceGraph,
+        },
+        roblox_resource_manager::{
+            outputs::ExperienceOutputs, ExperienceActivationInputs, ExperienceInputs, RobloxInputs,
+            RobloxOutputs, RobloxResource,
+        },
+        state::v7::{DeploymentKind, DeploymentStatus, EnvironmentStateV7, ResourceStateV7},
+    };
+
+    use super::*;
+
+    fn experience(asset_id: u64) -> RobloxResource {
+        RobloxResource::existing(
+            "experience_singleton",
+            RobloxInputs::Experience(ExperienceInputs { group_id: None }),
+            RobloxOutputs::Experience(ExperienceOutputs {
+                asset_id,
+                start_place_id: asset_id + 1,
+            }),
+            &[],
+        )
+    }
+
+    fn activation(enabled: bool, experience: &RobloxResource) -> RobloxResource {
+        RobloxResource::existing(
+            "experienceActivation_singleton",
+            RobloxInputs::ExperienceActivation(ExperienceActivationInputs { is_active: enabled }),
+            RobloxOutputs::ExperienceActivation,
+            &[experience],
+        )
+    }
+
+    #[test]
+    fn rollback_snapshot_uses_latest_record_baseline() {
+        let baseline = vec![experience(100)];
+        let desired = vec![experience(200)];
+        let record = crate::state::v7::DeploymentRecord {
+            id: "deploy-2".to_owned(),
+            kind: DeploymentKind::Deploy,
+            status: DeploymentStatus::Failed,
+            started_at: "2026-01-01T00:00:00Z".to_owned(),
+            finished_at: None,
+            baseline: baseline.clone(),
+            desired,
+            resulting: Vec::new(),
+            journal: Vec::new(),
+            summary: None,
+            source_revision: None,
+        };
+        let state = ResourceStateV7 {
+            environments: BTreeMap::from([(
+                "prod".to_owned(),
+                EnvironmentStateV7 {
+                    current: vec![experience(300)],
+                    deployments: vec![record],
+                },
+            )]),
+        };
+
+        let snapshot = rollback_snapshot(&state, "prod").unwrap();
+        assert_eq!(snapshot.len(), 1);
+        assert!(matches!(
+            snapshot[0].get_outputs(),
+            Some(RobloxOutputs::Experience(_))
+        ));
+    }
+
+    #[test]
+    fn failure_journal_captures_applied_and_failed_entries() {
+        let baseline_experience = experience(100);
+        let baseline_activation = activation(false, &baseline_experience);
+        let baseline_graph =
+            ResourceGraph::new(&[baseline_experience.clone(), baseline_activation]);
+
+        let resulting_experience = experience(100);
+        let resulting_activation = activation(true, &resulting_experience);
+        let mut resulting_graph = ResourceGraph::new(&[resulting_experience, resulting_activation]);
+
+        let evaluate_error = EvaluateError {
+            results: EvaluateResults {
+                updated_count: 1,
+                ..Default::default()
+            },
+            failures: vec![ResourceFailure {
+                resource_id: "badge_icon".to_owned(),
+                error: OperationError::from_diagnostic(
+                    DeploymentDiagnostic::error(
+                        "rollback-failed",
+                        DiagnosticCategory::Rollback,
+                        "Rollback failed for badge_icon.",
+                    )
+                    .with_operation(crate::diagnostics::OperationContext {
+                        action: OperationAction::Update,
+                        resource_id: Some("badge_icon".to_owned()),
+                        resource_type: "BadgeIcon".to_owned(),
+                        auth_model: "cookie-session".to_owned(),
+                        creator_target: None,
+                        endpoint: None,
+                        file_path: None,
+                    }),
+                ),
+            }],
+        };
+
+        let journal = build_failure_journal(&baseline_graph, &mut resulting_graph, &evaluate_error);
+
+        assert!(journal.iter().any(|entry| {
+            entry.resource_id == "experienceActivation_singleton"
+                && entry.status == crate::state::v7::DeploymentJournalStatus::Applied
+        }));
+        assert!(journal.iter().any(|entry| {
+            entry.resource_id == "badge_icon"
+                && entry.status == crate::state::v7::DeploymentJournalStatus::Failed
+        }));
+    }
+}

--- a/rbx_lithos/src/state/history.rs
+++ b/rbx_lithos/src/state/history.rs
@@ -144,7 +144,7 @@ mod tests {
 
         let resulting_experience = experience(100);
         let resulting_activation = activation(true, &resulting_experience);
-        let mut resulting_graph = ResourceGraph::new(&[resulting_experience, resulting_activation]);
+        let resulting_graph = ResourceGraph::new(&[resulting_experience, resulting_activation]);
 
         let evaluate_error = EvaluateError {
             results: EvaluateResults {
@@ -172,7 +172,7 @@ mod tests {
             }],
         };
 
-        let journal = build_failure_journal(&baseline_graph, &mut resulting_graph, &evaluate_error);
+        let journal = build_failure_journal(&baseline_graph, &resulting_graph, &evaluate_error);
 
         assert!(journal.iter().any(|entry| {
             entry.resource_id == "experienceActivation_singleton"

--- a/rbx_lithos/src/state/io.rs
+++ b/rbx_lithos/src/state/io.rs
@@ -23,6 +23,7 @@ use crate::config::{Config, EnvironmentConfig, RemoteStateConfig, StateConfig};
 use super::{
     aws_credentials_provider::AwsCredentialsProvider, v1::ResourceStateV1, v2::ResourceStateV2,
     v3::ResourceStateV3, v4::ResourceStateV4, v5::ResourceStateV5, v6::ResourceStateV6,
+    v7::ResourceStateV7,
 };
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -47,9 +48,11 @@ enum VersionedResourceState {
     V5(ResourceStateV5),
     #[serde(rename = "6")]
     V6(ResourceStateV6),
+    #[serde(rename = "7")]
+    V7(ResourceStateV7),
 }
 
-pub type ResourceStateVLatest = ResourceStateV6;
+pub type ResourceStateVLatest = ResourceStateV7;
 
 const STATE_SUFFIX: &str = ".lithos-state.yml";
 const LEGACY_STATE_SUFFIX: &str = ".mantle-state.yml";
@@ -209,27 +212,34 @@ pub async fn get_state_from_source(
 
     // Migrate previous state formats
     Ok(match state {
-        Some(ResourceState::Unversioned(state)) => ResourceStateV6::from(ResourceStateV5::from(
-            ResourceStateV4::from(ResourceStateV3::from(ResourceStateV2::from(state))),
-        )),
-        Some(ResourceState::Versioned(VersionedResourceState::V1(state))) => {
-            ResourceStateV6::from(ResourceStateV5::from(ResourceStateV4::from(
-                ResourceStateV3::from(ResourceStateV2::from(state)),
+        Some(ResourceState::Unversioned(state)) => {
+            ResourceStateV7::from(ResourceStateV6::from(ResourceStateV5::from(
+                ResourceStateV4::from(ResourceStateV3::from(ResourceStateV2::from(state))),
             )))
         }
-        Some(ResourceState::Versioned(VersionedResourceState::V2(state))) => ResourceStateV6::from(
-            ResourceStateV5::from(ResourceStateV4::from(ResourceStateV3::from(state))),
-        ),
-        Some(ResourceState::Versioned(VersionedResourceState::V3(state))) => {
-            ResourceStateV6::from(ResourceStateV5::from(ResourceStateV4::from(state)))
+        Some(ResourceState::Versioned(VersionedResourceState::V1(state))) => {
+            ResourceStateV7::from(ResourceStateV6::from(ResourceStateV5::from(
+                ResourceStateV4::from(ResourceStateV3::from(ResourceStateV2::from(state))),
+            )))
         }
+        Some(ResourceState::Versioned(VersionedResourceState::V2(state))) => {
+            ResourceStateV7::from(ResourceStateV6::from(ResourceStateV5::from(
+                ResourceStateV4::from(ResourceStateV3::from(state)),
+            )))
+        }
+        Some(ResourceState::Versioned(VersionedResourceState::V3(state))) => ResourceStateV7::from(
+            ResourceStateV6::from(ResourceStateV5::from(ResourceStateV4::from(state))),
+        ),
         Some(ResourceState::Versioned(VersionedResourceState::V4(state))) => {
-            ResourceStateV6::from(ResourceStateV5::from(state))
+            ResourceStateV7::from(ResourceStateV6::from(ResourceStateV5::from(state)))
         }
         Some(ResourceState::Versioned(VersionedResourceState::V5(state))) => {
-            ResourceStateV6::from(state)
+            ResourceStateV7::from(ResourceStateV6::from(state))
         }
-        Some(ResourceState::Versioned(VersionedResourceState::V6(state))) => state,
+        Some(ResourceState::Versioned(VersionedResourceState::V6(state))) => {
+            ResourceStateV7::from(state)
+        }
+        Some(ResourceState::Versioned(VersionedResourceState::V7(state))) => state,
         None => ResourceStateVLatest {
             environments: BTreeMap::new(),
         },
@@ -255,9 +265,10 @@ pub async fn get_previous_state(
             "No previous state for environment {}",
             Paint::cyan(environment_config.label.clone())
         ));
-        state
-            .environments
-            .insert(environment_config.label.clone(), Vec::new());
+        state.environments.insert(
+            environment_config.label.clone(),
+            super::v7::EnvironmentStateV7::default(),
+        );
     }
 
     Ok(state)
@@ -314,7 +325,7 @@ fn serialize_state(state: &ResourceStateVLatest) -> Result<Vec<u8>, String> {
                                 utc.format("%FT%TZ")
                             ).as_bytes().to_vec();
 
-    let state_data = serde_yaml::to_vec(&ResourceState::Versioned(VersionedResourceState::V6(
+    let state_data = serde_yaml::to_vec(&ResourceState::Versioned(VersionedResourceState::V7(
         state.to_owned(),
     )))
     .map_err(|e| format!("Unable to serialize state\n\t{}", e))?;

--- a/rbx_lithos/src/state/mod.rs
+++ b/rbx_lithos/src/state/mod.rs
@@ -6,8 +6,10 @@
 
 mod aws_credentials_provider;
 mod build;
+mod history;
 mod io;
 mod legacy_resources;
+mod progress;
 pub mod reconcile;
 pub mod v1;
 pub mod v2;
@@ -15,12 +17,17 @@ pub mod v3;
 pub mod v4;
 pub mod v5;
 pub mod v6;
+pub mod v7;
 
 pub use build::{get_desired_graph, import_graph};
+pub use history::{
+    build_failure_journal, build_success_journal, latest_deployment_diagnostics, rollback_snapshot,
+};
 pub use io::{
     get_previous_state, get_state, get_state_from_source, save_state, save_state_to_file,
     save_state_to_remote, ResourceStateVLatest,
 };
+pub use progress::DeploymentProgressWriter;
 pub use reconcile::{
     reconcile_graph, reconcile_graph_with_statuses, verify_graph, LiveStateVerifier,
     ReconciliationCounts, ReconciliationReport, RobloxLiveStateVerifier, VerificationStatus,

--- a/rbx_lithos/src/state/progress.rs
+++ b/rbx_lithos/src/state/progress.rs
@@ -1,0 +1,103 @@
+use std::path::Path;
+
+use async_trait::async_trait;
+
+use crate::{
+    config::StateConfig,
+    resource_graph::{
+        EvaluateError, EvaluateProgressHandler, EvaluateResults, ResourceFailure, ResourceGraph,
+    },
+    roblox_resource_manager::{RobloxInputs, RobloxOutputs, RobloxResource},
+};
+
+use super::{
+    history::{build_failure_journal, build_success_journal},
+    io::{save_state, ResourceStateVLatest},
+};
+
+pub struct DeploymentProgressWriter<'a> {
+    project_path: &'a Path,
+    state_config: &'a StateConfig,
+    state: &'a mut ResourceStateVLatest,
+    environment_label: &'a str,
+    deployment_id: &'a str,
+    baseline_graph: &'a ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs>,
+}
+
+impl<'a> DeploymentProgressWriter<'a> {
+    pub fn new(
+        project_path: &'a Path,
+        state_config: &'a StateConfig,
+        state: &'a mut ResourceStateVLatest,
+        environment_label: &'a str,
+        deployment_id: &'a str,
+        baseline_graph: &'a ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs>,
+    ) -> Self {
+        Self {
+            project_path,
+            state_config,
+            state,
+            environment_label,
+            deployment_id,
+            baseline_graph,
+        }
+    }
+
+    fn progress_summary(results: &EvaluateResults, failures: &[ResourceFailure]) -> String {
+        if failures.is_empty() {
+            format!(
+                "In progress: applied {} create(s), {} update(s), {} delete(s), {} noop(s), {} skip(s)",
+                results.created_count,
+                results.updated_count,
+                results.deleted_count,
+                results.noop_count,
+                results.skipped_count
+            )
+        } else {
+            format!(
+                "In progress: applied {} create(s), {} update(s), {} delete(s), {} noop(s), {} skip(s), {} failure(s)",
+                results.created_count,
+                results.updated_count,
+                results.deleted_count,
+                results.noop_count,
+                results.skipped_count,
+                failures.len()
+            )
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl EvaluateProgressHandler<RobloxResource, RobloxInputs, RobloxOutputs>
+    for DeploymentProgressWriter<'_>
+{
+    async fn persist_progress(
+        &mut self,
+        current_graph: &ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs>,
+        results: &EvaluateResults,
+        failures: &[ResourceFailure],
+    ) -> Result<(), String> {
+        let journal = if failures.is_empty() {
+            build_success_journal(self.baseline_graph, current_graph)
+        } else {
+            build_failure_journal(
+                self.baseline_graph,
+                current_graph,
+                &EvaluateError {
+                    results: results.clone(),
+                    failures: failures.to_vec(),
+                },
+            )
+        };
+
+        self.state.update_deployment_progress(
+            self.environment_label,
+            self.deployment_id,
+            current_graph.get_resource_list(),
+            journal,
+            Some(Self::progress_summary(results, failures)),
+        );
+
+        save_state(self.project_path, self.state_config, self.state).await
+    }
+}

--- a/rbx_lithos/src/state/v7.rs
+++ b/rbx_lithos/src/state/v7.rs
@@ -1,0 +1,395 @@
+use std::collections::BTreeMap;
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    diagnostics::{DeploymentDiagnostic, OperationAction},
+    resource_graph::ResourceGraph,
+    roblox_resource_manager::{RobloxInputs, RobloxOutputs, RobloxResource},
+};
+
+use super::v6::ResourceStateV6;
+
+const MAX_DEPLOYMENT_HISTORY: usize = 10;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ResourceStateV7 {
+    pub environments: BTreeMap<String, EnvironmentStateV7>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct EnvironmentStateV7 {
+    #[serde(default)]
+    pub current: Vec<RobloxResource>,
+    #[serde(default)]
+    pub deployments: Vec<DeploymentRecord>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DeploymentRecord {
+    pub id: String,
+    pub kind: DeploymentKind,
+    pub status: DeploymentStatus,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+    #[serde(default)]
+    pub baseline: Vec<RobloxResource>,
+    #[serde(default)]
+    pub desired: Vec<RobloxResource>,
+    #[serde(default)]
+    pub resulting: Vec<RobloxResource>,
+    #[serde(default)]
+    pub journal: Vec<DeploymentJournalEntry>,
+    pub summary: Option<String>,
+    pub source_revision: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum DeploymentKind {
+    Deploy,
+    Undo,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum DeploymentStatus {
+    InProgress,
+    Succeeded,
+    Failed,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DeploymentJournalEntry {
+    pub resource_id: String,
+    pub action: OperationAction,
+    pub status: DeploymentJournalStatus,
+    pub summary: String,
+    #[serde(default)]
+    pub diagnostics: Vec<DeploymentDiagnostic>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum DeploymentJournalStatus {
+    Applied,
+    Failed,
+}
+
+impl From<ResourceStateV6> for ResourceStateV7 {
+    fn from(state: ResourceStateV6) -> Self {
+        Self {
+            environments: state
+                .environments
+                .into_iter()
+                .map(|(label, resources)| {
+                    (
+                        label,
+                        EnvironmentStateV7 {
+                            current: resources,
+                            deployments: Vec::new(),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+impl ResourceStateV7 {
+    pub fn ensure_environment_mut(&mut self, label: &str) -> &mut EnvironmentStateV7 {
+        self.environments.entry(label.to_owned()).or_default()
+    }
+
+    pub fn environment(&self, label: &str) -> Option<&EnvironmentStateV7> {
+        self.environments.get(label)
+    }
+
+    pub fn current_resources(&self, label: &str) -> Option<&Vec<RobloxResource>> {
+        self.environment(label)
+            .map(|environment| &environment.current)
+    }
+
+    pub fn begin_deployment(
+        &mut self,
+        label: &str,
+        kind: DeploymentKind,
+        baseline: Vec<RobloxResource>,
+        desired: Vec<RobloxResource>,
+        source_revision: Option<String>,
+    ) -> String {
+        let id = format!(
+            "{}-{}",
+            match kind {
+                DeploymentKind::Deploy => "deploy",
+                DeploymentKind::Undo => "undo",
+            },
+            Utc::now().timestamp_millis()
+        );
+
+        let environment = self.ensure_environment_mut(label);
+        environment.deployments.push(DeploymentRecord {
+            id: id.clone(),
+            kind,
+            status: DeploymentStatus::InProgress,
+            started_at: Utc::now().to_rfc3339(),
+            finished_at: None,
+            baseline,
+            desired,
+            resulting: Vec::new(),
+            journal: Vec::new(),
+            summary: None,
+            source_revision,
+        });
+        trim_history(environment);
+
+        id
+    }
+
+    pub fn complete_deployment(
+        &mut self,
+        label: &str,
+        deployment_id: &str,
+        status: DeploymentStatus,
+        resulting: Vec<RobloxResource>,
+        journal: Vec<DeploymentJournalEntry>,
+        summary: Option<String>,
+    ) {
+        let environment = self.ensure_environment_mut(label);
+        if let Some(record) = environment
+            .deployments
+            .iter_mut()
+            .rev()
+            .find(|record| record.id == deployment_id)
+        {
+            record.status = status;
+            record.finished_at = Some(Utc::now().to_rfc3339());
+            record.resulting = resulting.clone();
+            record.journal = journal;
+            record.summary = summary;
+        }
+
+        if matches!(status, DeploymentStatus::Succeeded) {
+            environment.current = resulting;
+        }
+    }
+
+    pub fn update_deployment_progress(
+        &mut self,
+        label: &str,
+        deployment_id: &str,
+        resulting: Vec<RobloxResource>,
+        journal: Vec<DeploymentJournalEntry>,
+        summary: Option<String>,
+    ) {
+        let environment = self.ensure_environment_mut(label);
+        if let Some(record) = environment
+            .deployments
+            .iter_mut()
+            .rev()
+            .find(|record| record.id == deployment_id)
+        {
+            record.status = DeploymentStatus::InProgress;
+            record.resulting = resulting;
+            record.journal = journal;
+            record.summary = summary;
+        }
+    }
+
+    pub fn latest_rollback_record(&self, label: &str) -> Option<&DeploymentRecord> {
+        self.environment(label)?
+            .deployments
+            .iter()
+            .rev()
+            .find(|record| {
+                !record.baseline.is_empty()
+                    && matches!(
+                        record.status,
+                        DeploymentStatus::InProgress
+                            | DeploymentStatus::Failed
+                            | DeploymentStatus::Succeeded
+                    )
+            })
+    }
+}
+
+pub fn build_applied_journal(
+    baseline_graph: &ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs>,
+    resulting_graph: &ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs>,
+) -> Vec<DeploymentJournalEntry> {
+    let mut journal = Vec::new();
+
+    if let Ok(diff) = resulting_graph.diff(baseline_graph) {
+        journal.extend(
+            diff.additions
+                .keys()
+                .map(|resource_id| DeploymentJournalEntry {
+                    resource_id: resource_id.clone(),
+                    action: OperationAction::Create,
+                    status: DeploymentJournalStatus::Applied,
+                    summary: format!("Applied create for {}", resource_id),
+                    diagnostics: Vec::new(),
+                }),
+        );
+        journal.extend(
+            diff.changes
+                .keys()
+                .map(|resource_id| DeploymentJournalEntry {
+                    resource_id: resource_id.clone(),
+                    action: OperationAction::Update,
+                    status: DeploymentJournalStatus::Applied,
+                    summary: format!("Applied update for {}", resource_id),
+                    diagnostics: Vec::new(),
+                }),
+        );
+        journal.extend(
+            diff.removals
+                .keys()
+                .map(|resource_id| DeploymentJournalEntry {
+                    resource_id: resource_id.clone(),
+                    action: OperationAction::Delete,
+                    status: DeploymentJournalStatus::Applied,
+                    summary: format!("Applied delete for {}", resource_id),
+                    diagnostics: Vec::new(),
+                }),
+        );
+    }
+
+    journal
+}
+
+fn trim_history(environment: &mut EnvironmentStateV7) {
+    if environment.deployments.len() > MAX_DEPLOYMENT_HISTORY {
+        let overflow = environment.deployments.len() - MAX_DEPLOYMENT_HISTORY;
+        environment.deployments.drain(0..overflow);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        resource_graph::Resource,
+        roblox_resource_manager::{ExperienceInputs, RobloxInputs},
+    };
+
+    fn resource(id: &str) -> RobloxResource {
+        RobloxResource::new(
+            id,
+            RobloxInputs::Experience(ExperienceInputs { group_id: None }),
+            &[],
+        )
+    }
+
+    #[test]
+    fn migrates_v6_into_environment_state() {
+        let migrated = ResourceStateV7::from(ResourceStateV6 {
+            environments: BTreeMap::from([(
+                "prod".to_owned(),
+                vec![resource("experience_singleton")],
+            )]),
+        });
+
+        assert_eq!(migrated.current_resources("prod").unwrap().len(), 1);
+        assert!(migrated.environment("prod").unwrap().deployments.is_empty());
+    }
+
+    #[test]
+    fn prefers_latest_rollback_record() {
+        let mut state = ResourceStateV7 {
+            environments: BTreeMap::new(),
+        };
+        let baseline = vec![resource("baseline")];
+        let desired = vec![resource("desired")];
+        let first = state.begin_deployment(
+            "prod",
+            DeploymentKind::Deploy,
+            baseline.clone(),
+            desired.clone(),
+            None,
+        );
+        state.complete_deployment(
+            "prod",
+            &first,
+            DeploymentStatus::Succeeded,
+            desired.clone(),
+            Vec::new(),
+            Some("ok".to_owned()),
+        );
+        let second = state.begin_deployment(
+            "prod",
+            DeploymentKind::Deploy,
+            desired,
+            baseline.clone(),
+            None,
+        );
+
+        assert_eq!(state.latest_rollback_record("prod").unwrap().id, second);
+
+        state.complete_deployment(
+            "prod",
+            &second,
+            DeploymentStatus::Failed,
+            baseline,
+            Vec::new(),
+            Some("failed".to_owned()),
+        );
+
+        assert_eq!(state.latest_rollback_record("prod").unwrap().id, second);
+    }
+
+    #[test]
+    fn updates_in_progress_deployment_without_advancing_current() {
+        let mut state = ResourceStateV7 {
+            environments: BTreeMap::from([(
+                "prod".to_owned(),
+                EnvironmentStateV7 {
+                    current: vec![resource("current")],
+                    deployments: Vec::new(),
+                },
+            )]),
+        };
+
+        let deployment_id = state.begin_deployment(
+            "prod",
+            DeploymentKind::Deploy,
+            vec![resource("baseline")],
+            vec![resource("desired")],
+            None,
+        );
+        let partial_result = vec![resource("partial")];
+        let journal = vec![DeploymentJournalEntry {
+            resource_id: "partial".to_owned(),
+            action: OperationAction::Create,
+            status: DeploymentJournalStatus::Applied,
+            summary: "Applied create for partial".to_owned(),
+            diagnostics: Vec::new(),
+        }];
+
+        state.update_deployment_progress(
+            "prod",
+            &deployment_id,
+            partial_result.clone(),
+            journal.clone(),
+            Some("In progress".to_owned()),
+        );
+
+        let environment = state.environment("prod").unwrap();
+        assert_eq!(environment.current.len(), 1);
+        assert_eq!(environment.current[0].get_id(), "current");
+
+        let record = environment
+            .deployments
+            .iter()
+            .find(|record| record.id == deployment_id)
+            .unwrap();
+        assert!(matches!(record.status, DeploymentStatus::InProgress));
+        assert_eq!(record.resulting.len(), partial_result.len());
+        assert_eq!(record.journal.len(), journal.len());
+        assert_eq!(record.summary.as_deref(), Some("In progress"));
+    }
+}


### PR DESCRIPTION
## Summary

This PR improves deploy reliability in two connected ways:

1. It adds a preflight diagnostics layer that turns vague Roblox/Open Cloud failures into actionable validation errors and operator guidance before a deploy starts mutating anything.
2. It adds rollback checkpoints plus a new `lithos undo` workflow so a failed or bad deploy can be driven back toward the last known good state.

The goal is to make deploys easier to trust, easier to debug, and easier to recover from when Roblox responds with unclear or partial failures.

## What Changed

### Structured diagnostics and error mapping
- Added a central diagnostics module in `rbx_lithos` for deploy-time validation and Roblox failure classification.
- Introduced typed deployment diagnostics with severity, category, confidence, likely causes, and next steps.
- Mapped vague Roblox/Open Cloud errors into clearer user-facing guidance, especially around:
  - missing Open Cloud keys
  - missing `universe-places.write`
  - API key universe mismatches
  - unsupported target-access combinations
  - place publishing failures
  - large place file uploads near Roblox limits

### Typed operation failures through the apply pipeline
- Reworked resource graph evaluation and Roblox resource manager operations to return structured `OperationError` / `EvaluateError` values instead of opaque string failures.
- Updated create, update, delete, and price operations to classify failures with resource-specific context.
- Improved logging during apply so failures include probable causes and concrete recovery steps.

### Deploy preflight integration
- Wired preflight checks into the main deploy path before confirmation and before mutation.
- Extended preview output to surface:
  - preflight warnings / blockers
  - rollback readiness information
- Kept deploy on the existing pipeline instead of creating a second execution path.

### Rollback state and deployment history
- Added state v7 with per-environment:
  - current resource graph
  - deployment history
  - baseline / desired / resulting snapshots
  - deployment journals
- Added helpers to build success/failure journals and select rollback snapshots.
- Preserved migration compatibility from older state versions.

### New `undo` command
- Added a new `lithos undo` command to perform best-effort rollback to the last recorded checkpoint.
- `undo`:
  - loads the latest rollback snapshot from state history
  - imports live Roblox state
  - runs the same preflight and preview flow as deploy
  - applies a rollback diff toward the saved snapshot
  - records the result back into deployment history

### Crash-resilient progress persistence
- Added incremental progress persistence during apply.
- After each successful mutation, Lithos now updates the in-progress deployment record’s partial resulting graph and journal.
- `current` remains the last known good state, while in-progress deployment metadata captures partial apply progress for recovery after a crash.

### Auth and API key improvements
- Added Open Cloud API key introspection support in `rbx_api`.
- Aligned env-var handling with the docs by accepting:
  - `LITHOS_OPEN_CLOUD_API_KEY` (preferred)
  - `ROBLOX_OPEN_CLOUD_API_KEY`
  - `MANTLE_OPEN_CLOUD_API_KEY`

### Docs and UX updates
- Updated README, docs, examples, and migration guidance to document:
  - preflight diagnostics
  - rollback checkpoints
  - the new `undo` command
  - state v7 history behavior
- Fixed several docs formatting/rendering issues introduced during the docs updates.

## Why

Before this change, deploy failures could be hard to act on because Roblox often returns generic errors, and recovery from partial apply state required too much manual reconstruction.

This PR improves that by:
- catching common failures before mutation
- surfacing actionable operator guidance instead of vague API errors
- recording rollback checkpoints automatically
- enabling best-effort recovery through `lithos undo`
- preserving partial progress when a deploy crashes mid-apply

## Notes / Limitations

- `undo` is best-effort, not transactional. It reconciles live Roblox state and drives resources back toward the last recorded checkpoint, but Roblox-side mutations are still non-atomic.
- Incremental progress persistence records partial apply state in the in-progress deployment record, while leaving `current` as the last known good state.