### PR TITLE
feat: state lock on concurrent writes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -150,7 +150,7 @@ body:
     attributes:
       label: Lithos version
       description: Output of `lithos --version` if available.
-      placeholder: lithos 0.3.0
+      placeholder: lithos 0.4.0
     validations:
       required: true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,7 +1957,7 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lithos"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "clap 2.34.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3021,6 +3021,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sha2",
+ "tempfile",
  "tokio",
  "url",
  "yansi 0.5.1",

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -45,6 +45,34 @@ the next save:
 4. Run `lithos deploy` once. Confirm a fresh `.lithos-state.yml` (or remote object) is produced.
 5. Delete the legacy `.mantle-state.yml` after verifying the new state.
 
+## Concurrency model (new in Lithos)
+
+Lithos serializes mutating commands per environment via an in-document
+lock plus compare-and-swap on every state write. This is a behavior
+change from Mantle, which trusted the shared remote state file as the
+only coordination point.
+
+Practical consequences when migrating:
+
+- The state document now has a top-level `locks:` map keyed by
+  environment label. It is `#[serde(default)]`, so older state files
+  continue to load unchanged; the field is added the first time Lithos
+  writes after acquiring a lock.
+- Two concurrent runs against the same environment no longer race. The
+  second one fails immediately with a diagnostic pointing at
+  `lithos lock break --environment <env>`. Cross-environment runs still
+  proceed in parallel.
+- Crashed or killed runs leave behind a lock that goes stale after
+  15 minutes (heartbeats are written on every progress update) and is
+  reclaimed automatically. Use `lithos lock list` to inspect, and
+  `lithos lock break --environment <env>` to recover faster.
+- For S3 / R2 backends, compare-and-swap is best-effort
+  (load-then-write); the in-document lock is the authoritative protection
+  against multi-writer corruption. Local state additionally uses an
+  atomic tmp + rename on save.
+
+Full details: **[State and reconciliation → Concurrency](docs/site/pages/docs/concepts/state.mdx)**.
+
 ## Documentation hosting
 
 The documentation site moved from Vercel (`mantledeploy.vercel.app`) to GitHub Pages. Every push to

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Releases are published from [`siriuslatte/lithos`](https://github.com/siriuslatt
 ```toml
 # foreman.toml
 [tools]
-lithos = { source = "siriuslatte/lithos", version = "0.3.0" }
+lithos = { source = "siriuslatte/lithos", version = "0.4.0" }
 ```
 
 ### Manual

--- a/docs/site/components/home-landing.tsx
+++ b/docs/site/components/home-landing.tsx
@@ -122,7 +122,7 @@ export function HomeLanding() {
 
         <div className="lithos-home-hero-shell">
           <div className="lithos-home-hero-content">
-            <span className="lithos-home-version">v0.3.0</span>
+            <span className="lithos-home-version">v0.4.0</span>
 
             <h1 className="lithos-home-title">Lithos</h1>
 

--- a/docs/site/pages/docs/concepts/state.mdx
+++ b/docs/site/pages/docs/concepts/state.mdx
@@ -121,6 +121,77 @@ lithos diff --live
 That prints the same diff a `deploy` would, against the reconciled state,
 without prompting and without writing.
 
+## Concurrency: locks and compare-and-swap
+
+Lithos serializes mutating operations (`deploy`, `undo`, `destroy`,
+`import`) on a per-environment basis. Two concurrent runs against the same
+environment will not race: one wins, the other fails fast with a
+diagnostic.
+
+This is implemented with two layers that live entirely inside the state
+document, so the protocol is identical for local files and for remote
+backends.
+
+### Compare-and-swap on every write
+
+Every mutating save is compare-and-swap (CAS). When a command loads state,
+it captures a revision handle (a content hash, plus an optional backend
+ETag when available). When it tries to save, the store rejects the write
+if the handle no longer matches what is on disk or in the bucket.
+
+If the conflict is on **a different environment**, Lithos automatically
+re-bases: it keeps the slice it just modified and merges in the other
+environment(s) from the latest version. Cross-environment runs therefore
+never block each other.
+
+If the conflict is on **the same environment**, the save aborts with a
+hard error. The command exits non-zero without persisting.
+
+For local state this is enforced by hashing the on-disk file plus a tmp +
+atomic-rename write. For S3/R2 it is best-effort (load-then-write); the
+authoritative protection in the multi-writer case is the in-document lock
+described next.
+
+### Environment-scoped locks
+
+Before a mutating command touches anything, it acquires an advisory lock
+for the target environment. The lock lives inside the state file (under a
+top-level `locks:` map keyed by environment label) and carries:
+
+- The owner id (hostname + pid + nanosecond timestamp).
+- The host, PID, and operation name (`deploy`, `undo`, …).
+- The time it was acquired and the last heartbeat.
+
+A second `lithos deploy --environment prod` while a first one is still
+running fails immediately with a diagnostic that names the holder and
+points at `lithos lock break`. Long-running deploys refresh the heartbeat
+on every progress write, so the lock stays fresh while real work is
+happening.
+
+### Stale-lock recovery
+
+If a run crashes, loses its network, or is killed, its lock will eventually
+go stale (heartbeat older than the TTL — 15 minutes by default). The next
+acquirer reclaims it automatically.
+
+For faster recovery — for example, you know the CI job that crashed five
+minutes ago is gone for good and you don't want to wait for the TTL — use
+the CLI:
+
+```bash
+# Show every lock currently held, with staleness flagged.
+lithos lock list
+
+# Forcibly release a specific environment's lock.
+lithos lock break --environment prod
+```
+
+Only break a lock after confirming no other Lithos process is still
+mutating that environment. Breaking the lock while a real deploy is in
+flight does not corrupt state — the running deploy's next CAS write will
+fail and the run will abort — but you will end up with a partial deploy
+and have to run again.
+
 ## Legacy `mantle.yml` / `.mantle-state.yml`
 
 Lithos reads both Mantle and Lithos config and state files. New writes use

--- a/docs/site/pages/docs/guides/migrating-from-mantle.mdx
+++ b/docs/site/pages/docs/guides/migrating-from-mantle.mdx
@@ -62,7 +62,7 @@ Update `foreman.toml`:
 ```toml filename="foreman.toml"
 [tools]
 - mantle = { source = "blake-mealey/mantle", version = "0.11" }
-+ lithos = { source = "siriuslatte/lithos", version = "0.3.0" }
++ lithos = { source = "siriuslatte/lithos", version = "0.4.0" }
 ```
 
 Run `foreman install`, then update scripts and CI commands to call `lithos`.

--- a/examples/foreman.toml
+++ b/examples/foreman.toml
@@ -1,4 +1,4 @@
 [tools]
 # `lithos` is the CLI binary. Releases are published from
 # https://github.com/siriuslatte/lithos/releases.
-lithos = { source = "siriuslatte/lithos", version = "0.3.0" }
+lithos = { source = "siriuslatte/lithos", version = "0.4.0" }

--- a/src/lithos/CHANGELOG.md
+++ b/src/lithos/CHANGELOG.md
@@ -1,5 +1,11 @@
 # lithos
 
+## 0.4.0
+
+### Minor Changes
+
+- Per-environment concurrency control for `deploy`, `undo`, `destroy`, and `import`. State writes are now compare-and-swap; cross-environment conflicts auto-merge, same-environment conflicts abort. Adds in-document environment locks with heartbeats and stale-lock recovery, plus a new `lithos lock list|break --environment <env>` CLI for inspecting and recovering locks left behind by crashed runs.
+
 ## 0.11.5
 
 ### Patch Changes

--- a/src/lithos/CHANGELOG.md
+++ b/src/lithos/CHANGELOG.md
@@ -6,8 +6,3 @@
 
 - Per-environment concurrency control for `deploy`, `undo`, `destroy`, and `import`. State writes are now compare-and-swap; cross-environment conflicts auto-merge, same-environment conflicts abort. Adds in-document environment locks with heartbeats and stale-lock recovery, plus a new `lithos lock list|break --environment <env>` CLI for inspecting and recovering locks left behind by crashed runs.
 
-## 0.11.5
-
-### Patch Changes
-
-- automatically grant new audio assets permission to the target experience

--- a/src/lithos/Cargo.toml
+++ b/src/lithos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lithos"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Infra-as-code and deployment tool for Roblox"
 license = "MIT"

--- a/src/lithos/src/cli.rs
+++ b/src/lithos/src/cli.rs
@@ -237,6 +237,36 @@ fn get_app() -> App<'static, 'static> {
                                 .takes_value(true))
                 )
         )
+        .subcommand(
+            SubCommand::with_name("lock")
+                .about("Inspect and recover environment-scoped state locks.")
+                .setting(AppSettings::ArgRequiredElseHelp)
+                .subcommand(
+                    SubCommand::with_name("list")
+                        .about("List all locks currently held in state.")
+                        .arg(
+                            Arg::with_name("PROJECT")
+                                .index(1)
+                                .help(PROJECT_HELP)
+                                .takes_value(true))
+                )
+                .subcommand(
+                    SubCommand::with_name("break")
+                        .about("Forcibly release a lock for an environment. Intended for recovering from crashed runs after confirming no other operation is still in flight.")
+                        .arg(
+                            Arg::with_name("PROJECT")
+                                .index(1)
+                                .help(PROJECT_HELP)
+                                .takes_value(true))
+                        .arg(
+                            Arg::with_name("environment")
+                                .long("environment")
+                                .help("The label of the environment whose lock should be released.")
+                                .value_name("ENVIRONMENT")
+                                .takes_value(true)
+                                .required(true))
+                )
+        )
 }
 
 pub async fn run_with(args: Vec<String>) -> i32 {
@@ -345,6 +375,19 @@ pub async fn run_with(args: Vec<String>) -> i32 {
                 commands::upload::run(
                     upload_matches.value_of("PROJECT"),
                     upload_matches.value_of("key"),
+                )
+                .await
+            }
+            _ => unreachable!(),
+        },
+        ("lock", Some(lock_matches)) => match lock_matches.subcommand() {
+            ("list", Some(list_matches)) => {
+                commands::lock::list(list_matches.value_of("PROJECT")).await
+            }
+            ("break", Some(break_matches)) => {
+                commands::lock::break_lock(
+                    break_matches.value_of("PROJECT"),
+                    break_matches.value_of("environment").unwrap(),
                 )
                 .await
             }

--- a/src/lithos/src/commands/deploy.rs
+++ b/src/lithos/src/commands/deploy.rs
@@ -10,9 +10,9 @@ use rbx_lithos::{
     roblox_resource_manager::{RobloxInputs, RobloxOutputs, RobloxResource, RobloxResourceManager},
     state::v7::{DeploymentKind, DeploymentStatus},
     state::{
-        build_failure_journal, build_success_journal, get_desired_graph, reconcile_graph,
-        save_state, DeploymentProgressWriter, ReconciliationReport, RobloxLiveStateVerifier,
-        VerificationStatus,
+        acquire_environment_lock, build_failure_journal, build_success_journal, get_desired_graph,
+        reconcile_graph, release_environment_lock, save_state_cas, DeploymentProgressWriter,
+        ReconciliationReport, RobloxLiveStateVerifier, SaveTarget, VerificationStatus,
     },
 };
 
@@ -221,6 +221,7 @@ pub async fn run(
     let Project {
         current_graph,
         mut state,
+        mut state_handle,
         environment_config,
         target_config,
         payment_source,
@@ -346,6 +347,22 @@ pub async fn run(
     }
 
     logger::start_action("Checkpointing last known good state:");
+    let lock_session = match acquire_environment_lock(
+        &project_path,
+        &state_config,
+        &mut state,
+        &mut state_handle,
+        &environment_config.label,
+        "deploy",
+    )
+    .await
+    {
+        Ok(session) => session,
+        Err(e) => {
+            logger::end_action(Paint::red(e));
+            return 1;
+        }
+    };
     let deployment_id = state.begin_deployment(
         &environment_config.label,
         DeploymentKind::Deploy,
@@ -353,22 +370,47 @@ pub async fn run(
         next_graph.get_resource_list(),
         None,
     );
-    match save_state(&project_path, &state_config, &state).await {
-        Ok(_) => logger::end_action("Succeeded"),
-        Err(e) => {
-            logger::end_action(Paint::red(e));
-            return 1;
-        }
-    };
+    {
+        let baseline = state.environment(&environment_config.label).cloned();
+        let target = SaveTarget::new(&environment_config.label, baseline);
+        match save_state_cas(
+            &project_path,
+            &state_config,
+            &mut state,
+            &state_handle,
+            &target,
+        )
+        .await
+        {
+            Ok(new_handle) => {
+                state_handle = new_handle;
+                logger::end_action("Succeeded");
+            }
+            Err(e) => {
+                logger::end_action(Paint::red(e));
+                let _ = release_environment_lock(
+                    &project_path,
+                    &state_config,
+                    &mut state,
+                    &mut state_handle,
+                    &lock_session,
+                )
+                .await;
+                return 1;
+            }
+        };
+    }
 
     let results = {
         let mut progress_writer = DeploymentProgressWriter::new(
             project_path.as_path(),
             &state_config,
             &mut state,
+            &mut state_handle,
             &environment_config.label,
             &deployment_id,
             &current_graph,
+            Some(&lock_session),
         );
         next_graph
             .evaluate_with_progress(
@@ -472,14 +514,51 @@ pub async fn run(
     }
 
     logger::start_action("Saving state:");
-    match save_state(&project_path, &state_config, &state).await {
-        Ok(_) => {}
-        Err(e) => {
-            logger::end_action(Paint::red(e));
-            return 1;
-        }
-    };
+    {
+        let baseline = state.environment(&environment_config.label).cloned();
+        let target = SaveTarget::new(&environment_config.label, baseline);
+        match save_state_cas(
+            &project_path,
+            &state_config,
+            &mut state,
+            &state_handle,
+            &target,
+        )
+        .await
+        {
+            Ok(new_handle) => {
+                state_handle = new_handle;
+            }
+            Err(e) => {
+                logger::end_action(Paint::red(e));
+                let _ = release_environment_lock(
+                    &project_path,
+                    &state_config,
+                    &mut state,
+                    &mut state_handle,
+                    &lock_session,
+                )
+                .await;
+                return 1;
+            }
+        };
+    }
     logger::end_action("Succeeded");
+
+    if let Err(e) = release_environment_lock(
+        &project_path,
+        &state_config,
+        &mut state,
+        &mut state_handle,
+        &lock_session,
+    )
+    .await
+    {
+        logger::log(Paint::yellow(format!(
+            "Warning: failed to release environment lock: {}",
+            e
+        )));
+    }
 
     log_target_results(&target_config, &next_graph);
 

--- a/src/lithos/src/commands/destroy.rs
+++ b/src/lithos/src/commands/destroy.rs
@@ -7,7 +7,7 @@ use rbx_lithos::{
     project::{load_project, Project},
     resource_graph::{EvaluateResults, ResourceGraph},
     roblox_resource_manager::RobloxResourceManager,
-    state::save_state,
+    state::{acquire_environment_lock, release_environment_lock, save_state_cas, SaveTarget},
 };
 
 pub async fn run(project: Option<&str>, environment: Option<&str>) -> i32 {
@@ -22,6 +22,7 @@ pub async fn run(project: Option<&str>, environment: Option<&str>) -> i32 {
     let Project {
         current_graph,
         mut state,
+        mut state_handle,
         environment_config,
         payment_source,
         state_config,
@@ -38,6 +39,23 @@ pub async fn run(project: Option<&str>, environment: Option<&str>) -> i32 {
         }
     };
     logger::end_action("Succeeded");
+
+    let lock_session = match acquire_environment_lock(
+        &project_path,
+        &state_config,
+        &mut state,
+        &mut state_handle,
+        &environment_config.label,
+        "destroy",
+    )
+    .await
+    {
+        Ok(session) => session,
+        Err(e) => {
+            logger::log(Paint::red(e));
+            return 1;
+        }
+    };
 
     logger::start_action("Destroying resources:");
     let mut resource_manager = match RobloxResourceManager::new(&project_path, payment_source).await
@@ -80,14 +98,51 @@ pub async fn run(project: Option<&str>, environment: Option<&str>) -> i32 {
             .ensure_environment_mut(&environment_config.label)
             .current = next_graph.get_resource_list();
     }
-    match save_state(&project_path, &state_config, &state).await {
-        Ok(_) => {}
-        Err(e) => {
-            logger::end_action(Paint::red(e));
-            return 1;
+    {
+        let baseline = state.environment(&environment_config.label).cloned();
+        let target = SaveTarget::new(&environment_config.label, baseline);
+        match save_state_cas(
+            &project_path,
+            &state_config,
+            &mut state,
+            &state_handle,
+            &target,
+        )
+        .await
+        {
+            Ok(new_handle) => {
+                state_handle = new_handle;
+            }
+            Err(e) => {
+                logger::end_action(Paint::red(e));
+                let _ = release_environment_lock(
+                    &project_path,
+                    &state_config,
+                    &mut state,
+                    &mut state_handle,
+                    &lock_session,
+                )
+                .await;
+                return 1;
+            }
         }
-    };
+    }
     logger::end_action("Succeeded");
+
+    if let Err(e) = release_environment_lock(
+        &project_path,
+        &state_config,
+        &mut state,
+        &mut state_handle,
+        &lock_session,
+    )
+    .await
+    {
+        logger::log(Paint::yellow(format!(
+            "Warning: failed to release environment lock: {}",
+            e
+        )));
+    }
 
     match &results {
         Ok(_) => 0,

--- a/src/lithos/src/commands/import.rs
+++ b/src/lithos/src/commands/import.rs
@@ -7,7 +7,10 @@ use yansi::Paint;
 use rbx_lithos::{
     config::load_project_config,
     project::{load_project, Project},
-    state::{import_graph, save_state},
+    state::{
+        acquire_environment_lock, import_graph, release_environment_lock, save_state_cas,
+        SaveTarget,
+    },
 };
 
 pub async fn run(project: Option<&str>, environment: Option<&str>, target_id: &str) -> i32 {
@@ -22,6 +25,7 @@ pub async fn run(project: Option<&str>, environment: Option<&str>, target_id: &s
     let Project {
         current_graph,
         mut state,
+        mut state_handle,
         environment_config,
         state_config,
         ..
@@ -89,17 +93,70 @@ pub async fn run(project: Option<&str>, environment: Option<&str>, target_id: &s
     logger::end_action("Succeeded");
 
     logger::start_action("Saving state:");
-    state
-        .ensure_environment_mut(&environment_config.label)
-        .current = imported_graph.get_resource_list();
-    match save_state(&project_path, &state_config, &state).await {
-        Ok(_) => {}
+    let lock_session = match acquire_environment_lock(
+        &project_path,
+        &state_config,
+        &mut state,
+        &mut state_handle,
+        &environment_config.label,
+        "import",
+    )
+    .await
+    {
+        Ok(session) => session,
         Err(e) => {
             logger::end_action(Paint::red(e));
             return 1;
         }
     };
+    state
+        .ensure_environment_mut(&environment_config.label)
+        .current = imported_graph.get_resource_list();
+    {
+        let baseline = state.environment(&environment_config.label).cloned();
+        let target = SaveTarget::new(&environment_config.label, baseline);
+        match save_state_cas(
+            &project_path,
+            &state_config,
+            &mut state,
+            &state_handle,
+            &target,
+        )
+        .await
+        {
+            Ok(new_handle) => {
+                state_handle = new_handle;
+            }
+            Err(e) => {
+                logger::end_action(Paint::red(e));
+                let _ = release_environment_lock(
+                    &project_path,
+                    &state_config,
+                    &mut state,
+                    &mut state_handle,
+                    &lock_session,
+                )
+                .await;
+                return 1;
+            }
+        }
+    }
     logger::end_action("Succeeded");
+
+    if let Err(e) = release_environment_lock(
+        &project_path,
+        &state_config,
+        &mut state,
+        &mut state_handle,
+        &lock_session,
+    )
+    .await
+    {
+        logger::log(Paint::yellow(format!(
+            "Warning: failed to release environment lock: {}",
+            e
+        )));
+    }
 
     0
 }

--- a/src/lithos/src/commands/lock.rs
+++ b/src/lithos/src/commands/lock.rs
@@ -1,0 +1,87 @@
+use yansi::Paint;
+
+use rbx_lithos::{
+    config::load_project_config,
+    state::{force_break_environment_lock, get_state, EnvironmentLock},
+};
+
+/// Print a single lock entry in human-readable form.
+fn print_lock(environment: &str, lock: &EnvironmentLock) {
+    let stale_marker = if lock.is_stale() {
+        Paint::yellow(" (stale)").to_string()
+    } else {
+        String::new()
+    };
+    logger::log(format!(
+        "{}{}: operation '{}' held by pid {} on {} (acquired {}, heartbeat {})",
+        Paint::cyan(environment),
+        stale_marker,
+        lock.operation,
+        lock.pid,
+        lock.host,
+        lock.acquired_at,
+        lock.heartbeat_at,
+    ));
+}
+
+pub async fn list(project: Option<&str>) -> i32 {
+    let (project_path, config) = match load_project_config(project) {
+        Ok(v) => v,
+        Err(e) => {
+            logger::log(Paint::red(e));
+            return 1;
+        }
+    };
+    let state = match get_state(&project_path, &config).await {
+        Ok(state) => state,
+        Err(e) => {
+            logger::log(Paint::red(e));
+            return 1;
+        }
+    };
+    let locks: Vec<_> = state.iter_environment_locks().collect();
+    if locks.is_empty() {
+        logger::log("No environment locks are currently held.");
+        return 0;
+    }
+    logger::start_action("Active environment locks:");
+    for (env, lock) in locks {
+        print_lock(env, lock);
+    }
+    logger::end_action_without_message();
+    0
+}
+
+pub async fn break_lock(project: Option<&str>, environment: &str) -> i32 {
+    let (project_path, config) = match load_project_config(project) {
+        Ok(v) => v,
+        Err(e) => {
+            logger::log(Paint::red(e));
+            return 1;
+        }
+    };
+    match force_break_environment_lock(&project_path, &config.state, environment).await {
+        Ok(Some(lock)) => {
+            logger::log(format!(
+                "Released lock on {} (was held by pid {} on {}, operation '{}', heartbeat {})",
+                Paint::cyan(environment),
+                lock.pid,
+                lock.host,
+                lock.operation,
+                lock.heartbeat_at,
+            ));
+            0
+        }
+        Ok(None) => {
+            logger::log(format!(
+                "No lock was held on environment {}",
+                Paint::cyan(environment)
+            ));
+            0
+        }
+        Err(e) => {
+            logger::log(Paint::red(e));
+            1
+        }
+    }
+}

--- a/src/lithos/src/commands/mod.rs
+++ b/src/lithos/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod destroy;
 pub mod diff;
 pub mod download;
 pub mod import;
+pub mod lock;
 pub mod outputs;
 pub mod undo;
 pub mod upload;

--- a/src/lithos/src/commands/undo.rs
+++ b/src/lithos/src/commands/undo.rs
@@ -7,9 +7,10 @@ use rbx_lithos::{
     resource_graph::{EvaluateResults, Resource, ResourceGraph},
     roblox_resource_manager::{RobloxOutputs, RobloxResource, RobloxResourceManager},
     state::{
-        build_failure_journal, build_success_journal, import_graph, save_state,
+        acquire_environment_lock, build_failure_journal, build_success_journal, import_graph,
+        release_environment_lock, save_state_cas,
         v7::{DeploymentKind, DeploymentStatus},
-        DeploymentProgressWriter,
+        DeploymentProgressWriter, SaveTarget,
     },
 };
 
@@ -105,6 +106,7 @@ pub async fn run(
     let Project {
         current_graph,
         mut state,
+        mut state_handle,
         environment_config,
         target_config,
         payment_source,
@@ -218,6 +220,22 @@ pub async fn run(
     }
 
     logger::start_action("Checkpointing pre-undo state:");
+    let lock_session = match acquire_environment_lock(
+        &project_path,
+        &state_config,
+        &mut state,
+        &mut state_handle,
+        &environment_config.label,
+        "undo",
+    )
+    .await
+    {
+        Ok(session) => session,
+        Err(e) => {
+            logger::end_action(Paint::red(e));
+            return 1;
+        }
+    };
     let deployment_id = state.begin_deployment(
         &environment_config.label,
         DeploymentKind::Undo,
@@ -225,13 +243,36 @@ pub async fn run(
         rollback_graph.get_resource_list(),
         None,
     );
-    match save_state(&project_path, &state_config, &state).await {
-        Ok(_) => logger::end_action("Succeeded"),
-        Err(e) => {
-            logger::end_action(Paint::red(e));
-            return 1;
+    {
+        let baseline = state.environment(&environment_config.label).cloned();
+        let target = SaveTarget::new(&environment_config.label, baseline);
+        match save_state_cas(
+            &project_path,
+            &state_config,
+            &mut state,
+            &state_handle,
+            &target,
+        )
+        .await
+        {
+            Ok(new_handle) => {
+                state_handle = new_handle;
+                logger::end_action("Succeeded");
+            }
+            Err(e) => {
+                logger::end_action(Paint::red(e));
+                let _ = release_environment_lock(
+                    &project_path,
+                    &state_config,
+                    &mut state,
+                    &mut state_handle,
+                    &lock_session,
+                )
+                .await;
+                return 1;
+            }
         }
-    };
+    }
 
     logger::start_action("Undoing resources:");
     let results = {
@@ -239,9 +280,11 @@ pub async fn run(
             project_path.as_path(),
             &state_config,
             &mut state,
+            &mut state_handle,
             &environment_config.label,
             &deployment_id,
             &live_graph,
+            Some(&lock_session),
         );
         rollback_graph
             .evaluate_with_progress(
@@ -326,13 +369,51 @@ pub async fn run(
     );
 
     logger::start_action("Saving state:");
-    match save_state(&project_path, &state_config, &state).await {
-        Ok(_) => logger::end_action("Succeeded"),
-        Err(e) => {
-            logger::end_action(Paint::red(e));
-            return 1;
+    {
+        let baseline = state.environment(&environment_config.label).cloned();
+        let target = SaveTarget::new(&environment_config.label, baseline);
+        match save_state_cas(
+            &project_path,
+            &state_config,
+            &mut state,
+            &state_handle,
+            &target,
+        )
+        .await
+        {
+            Ok(new_handle) => {
+                state_handle = new_handle;
+                logger::end_action("Succeeded");
+            }
+            Err(e) => {
+                logger::end_action(Paint::red(e));
+                let _ = release_environment_lock(
+                    &project_path,
+                    &state_config,
+                    &mut state,
+                    &mut state_handle,
+                    &lock_session,
+                )
+                .await;
+                return 1;
+            }
         }
-    };
+    }
+
+    if let Err(e) = release_environment_lock(
+        &project_path,
+        &state_config,
+        &mut state,
+        &mut state_handle,
+        &lock_session,
+    )
+    .await
+    {
+        logger::log(Paint::yellow(format!(
+            "Warning: failed to release environment lock: {}",
+            e
+        )));
+    }
 
     match results {
         Ok(_) => 0,

--- a/src/rbx_lithos/CHANGELOG.md
+++ b/src/rbx_lithos/CHANGELOG.md
@@ -1,7 +1,2 @@
 # rbx_lithos
 
-## 0.11.5
-
-### Patch Changes
-
-- automatically grant new audio assets permission to the target experience

--- a/src/rbx_lithos/Cargo.toml
+++ b/src/rbx_lithos/Cargo.toml
@@ -38,3 +38,4 @@ reqwest = "0.11"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "macros", "rt-multi-thread"] }
+tempfile = "3"

--- a/src/rbx_lithos/src/project.rs
+++ b/src/rbx_lithos/src/project.rs
@@ -11,7 +11,7 @@ use super::{
     },
     resource_graph::ResourceGraph,
     roblox_resource_manager::{RobloxInputs, RobloxOutputs, RobloxResource},
-    state::{get_previous_state, ResourceStateVLatest},
+    state::{get_previous_state_with_handle, ResourceStateVLatest, StateHandle},
 };
 
 fn run_command(dir: PathBuf, command: &str) -> std::io::Result<std::process::Output> {
@@ -150,6 +150,9 @@ fn get_target_config(
 pub struct Project {
     pub current_graph: ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs>,
     pub state: ResourceStateVLatest,
+    /// Revision token captured at state load time. Mutating commands
+    /// thread this through every save so concurrent writes are detected.
+    pub state_handle: StateHandle,
     pub environment_config: EnvironmentConfig,
     pub target_config: TargetConfig,
     pub payment_source: CreatorType,
@@ -220,7 +223,8 @@ pub async fn load_project(
     };
 
     // Get previous state
-    let state = get_previous_state(project_path.as_path(), &config, environment_config).await?;
+    let (state, state_handle) =
+        get_previous_state_with_handle(project_path.as_path(), &config, environment_config).await?;
 
     // Get our resource graphs
     let previous_graph = ResourceGraph::new(
@@ -232,6 +236,7 @@ pub async fn load_project(
     Ok(Some(Project {
         current_graph: previous_graph,
         state,
+        state_handle,
         environment_config: environment_config.clone(),
         target_config,
         payment_source,

--- a/src/rbx_lithos/src/state/history.rs
+++ b/src/rbx_lithos/src/state/history.rs
@@ -125,6 +125,7 @@ mod tests {
                     deployments: vec![record],
                 },
             )]),
+            locks: BTreeMap::new(),
         };
 
         let snapshot = rollback_snapshot(&state, "prod").unwrap();

--- a/src/rbx_lithos/src/state/io.rs
+++ b/src/rbx_lithos/src/state/io.rs
@@ -15,15 +15,20 @@ use rusoto_core::{HttpClient, Region};
 use rusoto_s3::{S3Client, S3};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use tokio::io::AsyncReadExt;
 use yansi::Paint;
 
 use crate::config::{Config, EnvironmentConfig, RemoteStateConfig, StateConfig};
 
 use super::{
-    aws_credentials_provider::AwsCredentialsProvider, v1::ResourceStateV1, v2::ResourceStateV2,
-    v3::ResourceStateV3, v4::ResourceStateV4, v5::ResourceStateV5, v6::ResourceStateV6,
-    v7::ResourceStateV7,
+    aws_credentials_provider::AwsCredentialsProvider,
+    store::{build_store, LoadedState, SaveError, StateHandle},
+    v1::ResourceStateV1,
+    v2::ResourceStateV2,
+    v3::ResourceStateV3,
+    v4::ResourceStateV4,
+    v5::ResourceStateV5,
+    v6::ResourceStateV6,
+    v7::{EnvironmentStateV7, ResourceStateV7},
 };
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -55,18 +60,9 @@ enum VersionedResourceState {
 pub type ResourceStateVLatest = ResourceStateV7;
 
 const STATE_SUFFIX: &str = ".lithos-state.yml";
-const LEGACY_STATE_SUFFIX: &str = ".mantle-state.yml";
 
 fn get_state_file_path(project_path: &Path, key: Option<&str>) -> PathBuf {
     project_path.join(format!("{}{}", key.unwrap_or_default(), STATE_SUFFIX))
-}
-
-fn get_legacy_state_file_path(project_path: &Path, key: Option<&str>) -> PathBuf {
-    project_path.join(format!(
-        "{}{}",
-        key.unwrap_or_default(),
-        LEGACY_STATE_SUFFIX
-    ))
 }
 
 fn get_hash(data: &[u8]) -> String {
@@ -90,50 +86,6 @@ fn parse_state(file_name: &str, data: &str) -> Result<ResourceState, String> {
         .map_err(|e| format!("Unable to parse state file {}\n\t{}", file_name, e))
 }
 
-fn get_state_from_file(
-    project_path: &Path,
-    key: Option<&str>,
-) -> Result<Option<ResourceState>, String> {
-    let state_file_path = get_state_file_path(project_path, key);
-    let legacy_state_file_path = get_legacy_state_file_path(project_path, key);
-
-    let resolved_path = if state_file_path.exists() {
-        state_file_path
-    } else if legacy_state_file_path.exists() {
-        logger::log(format!(
-            "{} Loading legacy state file '{}'. It will be migrated to '{}' on next save.",
-            Paint::yellow("warning:"),
-            legacy_state_file_path.display(),
-            get_state_file_path(project_path, key).display()
-        ));
-        legacy_state_file_path
-    } else {
-        logger::log(format!(
-            "Loading previous state from local file {}",
-            Paint::cyan(state_file_path.display())
-        ));
-        return Ok(None);
-    };
-
-    logger::log(format!(
-        "Loading previous state from local file {}",
-        Paint::cyan(resolved_path.display())
-    ));
-
-    let data = fs::read_to_string(&resolved_path).map_err(|e| {
-        format!(
-            "Unable to read state file: {}\n\t{}",
-            resolved_path.display(),
-            e
-        )
-    })?;
-
-    Ok(Some(parse_state(
-        &resolved_path.display().to_string(),
-        &data,
-    )?))
-}
-
 fn create_client(region: Region) -> S3Client {
     S3Client::new_with(
         HttpClient::new().unwrap(),
@@ -142,106 +94,100 @@ fn create_client(region: Region) -> S3Client {
     )
 }
 
-async fn get_state_from_remote(
-    config: &RemoteStateConfig,
-) -> Result<Option<ResourceState>, String> {
-    logger::log(format!(
-        "Loading previous state from remote object {}",
-        Paint::cyan(config)
-    ));
-
-    let client = create_client(config.region.clone());
-    let keys = [
-        (format!("{}.lithos-state.yml", config.key), false),
-        (format!("{}.mantle-state.yml", config.key), true),
-    ];
-
-    for (key, is_legacy) in keys.iter() {
-        let object_res = client
-            .get_object(rusoto_s3::GetObjectRequest {
-                bucket: config.bucket.clone(),
-                key: key.clone(),
-                ..Default::default()
-            })
-            .await;
-
-        match object_res {
-            Ok(object) => {
-                if *is_legacy {
-                    logger::log(format!(
-                        "{} Loaded legacy remote state object '{}'. It will be migrated to '{}.lithos-state.yml' on next save.",
-                        Paint::yellow("warning:"),
-                        key,
-                        config.key
-                    ));
-                }
-
-                if let Some(stream) = object.body {
-                    let mut buffer = String::new();
-                    stream
-                        .into_async_read()
-                        .read_to_string(&mut buffer)
-                        .await
-                        .map_err(|_| "".to_owned())?;
-                    return Ok(Some(parse_state(&format!("{}", config), &buffer)?));
-                }
-
-                return Ok(None);
-            }
-            Err(rusoto_core::RusotoError::Service(rusoto_s3::GetObjectError::NoSuchKey(_))) => {
-                continue
-            }
-            Err(e) => return Err(format!("Failed to get state from remote: {}", e)),
-        }
-    }
-
-    Ok(None)
-}
-
 pub async fn get_state_from_source(
     project_path: &Path,
     source: StateConfig,
 ) -> Result<ResourceStateVLatest, String> {
-    let state = match source {
-        StateConfig::Local => get_state_from_file(project_path, None)?,
-        StateConfig::LocalKey(key) => get_state_from_file(project_path, Some(&key))?,
-        StateConfig::Remote(config) => get_state_from_remote(&config).await?,
-    };
+    let (state, _handle) = load_state_from_source(project_path, &source).await?;
+    Ok(state)
+}
 
-    // Migrate previous state formats
-    Ok(match state {
-        Some(ResourceState::Unversioned(state)) => {
+/// Load the current state together with the [`StateHandle`] identifying the
+/// revision it came from. Mutating commands should use this entry point so
+/// they can pass the handle back to [`save_state_cas`] for safe writes.
+pub async fn load_state_from_source(
+    project_path: &Path,
+    source: &StateConfig,
+) -> Result<(ResourceStateVLatest, StateHandle), String> {
+    let store = build_store(project_path, source);
+    log_load_source(source);
+    let LoadedState { bytes, handle } = store.load().await?;
+    let state = match bytes {
+        None => ResourceStateVLatest {
+            environments: BTreeMap::new(),
+        },
+        Some(bytes) => parse_state_bytes(&store_label(source), &bytes)?,
+    };
+    Ok((state, handle))
+}
+
+/// Convenience wrapper around [`load_state_from_source`] that uses the state
+/// source declared by `config`.
+pub async fn load_state_with_handle(
+    project_path: &Path,
+    config: &Config,
+) -> Result<(ResourceStateVLatest, StateHandle), String> {
+    load_state_from_source(project_path, &config.state).await
+}
+
+fn log_load_source(source: &StateConfig) {
+    match source {
+        StateConfig::Local => logger::log("Loading previous state from local file".to_owned()),
+        StateConfig::LocalKey(key) => logger::log(format!(
+            "Loading previous state from local file with key {}",
+            Paint::cyan(key)
+        )),
+        StateConfig::Remote(config) => logger::log(format!(
+            "Loading previous state from remote object {}",
+            Paint::cyan(config)
+        )),
+    }
+}
+
+fn store_label(source: &StateConfig) -> String {
+    match source {
+        StateConfig::Local => "<local state>".to_owned(),
+        StateConfig::LocalKey(key) => format!("<local state '{}'>", key),
+        StateConfig::Remote(config) => format!("{}", config),
+    }
+}
+
+fn parse_state_bytes(label: &str, bytes: &[u8]) -> Result<ResourceStateVLatest, String> {
+    let text = std::str::from_utf8(bytes)
+        .map_err(|e| format!("State at {} is not valid UTF-8: {}", label, e))?;
+    let parsed = parse_state(label, text)?;
+    Ok(migrate_state(parsed))
+}
+
+fn migrate_state(state: ResourceState) -> ResourceStateVLatest {
+    match state {
+        ResourceState::Unversioned(state) => {
             ResourceStateV7::from(ResourceStateV6::from(ResourceStateV5::from(
                 ResourceStateV4::from(ResourceStateV3::from(ResourceStateV2::from(state))),
             )))
         }
-        Some(ResourceState::Versioned(VersionedResourceState::V1(state))) => {
+        ResourceState::Versioned(VersionedResourceState::V1(state)) => {
             ResourceStateV7::from(ResourceStateV6::from(ResourceStateV5::from(
                 ResourceStateV4::from(ResourceStateV3::from(ResourceStateV2::from(state))),
             )))
         }
-        Some(ResourceState::Versioned(VersionedResourceState::V2(state))) => {
+        ResourceState::Versioned(VersionedResourceState::V2(state)) => {
             ResourceStateV7::from(ResourceStateV6::from(ResourceStateV5::from(
                 ResourceStateV4::from(ResourceStateV3::from(state)),
             )))
         }
-        Some(ResourceState::Versioned(VersionedResourceState::V3(state))) => ResourceStateV7::from(
+        ResourceState::Versioned(VersionedResourceState::V3(state)) => ResourceStateV7::from(
             ResourceStateV6::from(ResourceStateV5::from(ResourceStateV4::from(state))),
         ),
-        Some(ResourceState::Versioned(VersionedResourceState::V4(state))) => {
+        ResourceState::Versioned(VersionedResourceState::V4(state)) => {
             ResourceStateV7::from(ResourceStateV6::from(ResourceStateV5::from(state)))
         }
-        Some(ResourceState::Versioned(VersionedResourceState::V5(state))) => {
+        ResourceState::Versioned(VersionedResourceState::V5(state)) => {
             ResourceStateV7::from(ResourceStateV6::from(state))
         }
-        Some(ResourceState::Versioned(VersionedResourceState::V6(state))) => {
-            ResourceStateV7::from(state)
-        }
-        Some(ResourceState::Versioned(VersionedResourceState::V7(state))) => state,
-        None => ResourceStateVLatest {
-            environments: BTreeMap::new(),
-        },
-    })
+        ResourceState::Versioned(VersionedResourceState::V6(state)) => ResourceStateV7::from(state),
+        ResourceState::Versioned(VersionedResourceState::V7(state)) => state,
+    }
 }
 
 pub async fn get_state(
@@ -333,16 +279,338 @@ fn serialize_state(state: &ResourceStateVLatest) -> Result<Vec<u8>, String> {
     Ok(data)
 }
 
+/// Best-effort save: load the latest revision, then CAS-write on top. On
+/// conflict the latest state is silently merged with no special target-env
+/// awareness, which is appropriate for whole-file admin commands like
+/// `upload` / `download`. Mutating workflows should prefer
+/// [`save_state_cas`] so they can describe which environment they own.
 pub async fn save_state(
     project_path: &Path,
     state_config: &StateConfig,
     state: &ResourceStateVLatest,
 ) -> Result<(), String> {
-    let data = serialize_state(state)?;
+    let store = build_store(project_path, state_config);
+    let current = store.load().await?;
+    let bytes = serialize_state(state)?;
+    log_save_destination(state_config);
+    match store.save(&bytes, &current.handle).await {
+        Ok(_) => Ok(()),
+        Err(SaveError::Other(e)) => Err(e),
+        Err(SaveError::Conflict { .. }) => Err(format!(
+            "Concurrent write detected while saving {}. Reload the state and retry.",
+            store.describe()
+        )),
+    }
+}
 
+/// Describes which environment a save is authoritatively updating, plus the
+/// snapshot of that environment as it existed at the start of the operation.
+/// Used by [`save_state_cas`] to distinguish "another writer touched a
+/// different environment" (merge and retry) from "another writer touched the
+/// same environment we are mutating" (fail fast).
+pub struct SaveTarget<'a> {
+    pub environment: &'a str,
+    pub baseline: Option<EnvironmentStateV7>,
+}
+
+impl<'a> SaveTarget<'a> {
+    pub fn new(environment: &'a str, baseline: Option<EnvironmentStateV7>) -> Self {
+        Self {
+            environment,
+            baseline,
+        }
+    }
+}
+
+/// Compare-and-swap save with per-environment conflict resolution.
+///
+/// `expected` must be the handle returned from the most recent successful
+/// load/save in this operation. `target` declares which environment this
+/// operation owns; on a CAS conflict:
+///
+/// - If the on-disk state's view of `target.environment` matches `target.baseline`,
+///   the conflict only touched *other* environments. We rebase by taking the
+///   on-disk state and overlaying our environment's slice on top, then retry.
+/// - Otherwise the conflict touched the same environment we own, which is
+///   not a safe state to recover from automatically — we return an error and
+///   the caller should surface it to the user.
+///
+/// On success `state` is updated in place so subsequent in-memory mutations
+/// build on the latest disk state, and the new [`StateHandle`] is returned.
+pub async fn save_state_cas(
+    project_path: &Path,
+    state_config: &StateConfig,
+    state: &mut ResourceStateVLatest,
+    expected: &StateHandle,
+    target: &SaveTarget<'_>,
+) -> Result<StateHandle, String> {
+    let store = build_store(project_path, state_config);
+    const MAX_RETRIES: u32 = 3;
+    let mut current_expected = expected.clone();
+    log_save_destination(state_config);
+
+    for attempt in 0..=MAX_RETRIES {
+        let bytes = serialize_state(state)?;
+        match store.save(&bytes, &current_expected).await {
+            Ok(new_handle) => return Ok(new_handle),
+            Err(SaveError::Other(e)) => return Err(e),
+            Err(SaveError::Conflict { latest }) => {
+                if attempt == MAX_RETRIES {
+                    return Err(format!(
+                        "Repeated concurrent writes to {} prevented a safe save after {} retries.",
+                        store.describe(),
+                        MAX_RETRIES
+                    ));
+                }
+                let latest_state = match latest.bytes.as_deref() {
+                    Some(bytes) => parse_state_bytes(&store_label(state_config), bytes)?,
+                    None => ResourceStateVLatest {
+                        environments: BTreeMap::new(),
+                    },
+                };
+                rebase_onto_latest(state, latest_state, target)?;
+                current_expected = latest.handle;
+            }
+        }
+    }
+    Err(format!(
+        "Unable to safely save state to {}",
+        store.describe()
+    ))
+}
+
+fn log_save_destination(state_config: &StateConfig) {
     match state_config {
-        StateConfig::Local => save_state_to_file(project_path, &data, None),
-        StateConfig::LocalKey(key) => save_state_to_file(project_path, &data, Some(key)),
-        StateConfig::Remote(config) => save_state_to_remote(config, &data).await,
+        StateConfig::Local => {
+            logger::log("Saving state to local file".to_owned());
+        }
+        StateConfig::LocalKey(key) => logger::log(format!(
+            "Saving state to local file with key {}",
+            Paint::cyan(key)
+        )),
+        StateConfig::Remote(config) => {
+            logger::log(format!(
+                "Saving state to remote object {}",
+                Paint::cyan(config)
+            ));
+        }
+    }
+}
+
+/// Reconcile our in-memory state with the latest on-disk state when only
+/// other environments changed. Returns an error if our owned environment is
+/// no longer the one we started from (a same-environment conflict).
+fn rebase_onto_latest(
+    state: &mut ResourceStateVLatest,
+    latest: ResourceStateVLatest,
+    target: &SaveTarget<'_>,
+) -> Result<(), String> {
+    let target_label = target.environment;
+    let latest_target = latest.environments.get(target_label);
+
+    let same_env_conflict = match (target.baseline.as_ref(), latest_target) {
+        (Some(baseline), Some(remote)) => !environments_equivalent(baseline, remote),
+        (Some(_), None) => true,
+        (None, Some(_)) => true,
+        (None, None) => false,
+    };
+
+    if same_env_conflict {
+        return Err(format!(
+            "Concurrent change detected for environment '{}'. Another writer modified the same \
+             environment while this operation was in progress; refusing to overwrite their \
+             changes. Re-run the command once the other operation has finished.",
+            target_label
+        ));
+    }
+
+    // Take everything from the latest snapshot and overlay our target env.
+    let our_env = state.environments.remove(target_label);
+    let mut merged = latest;
+    if let Some(our_env) = our_env {
+        merged.environments.insert(target_label.to_owned(), our_env);
+    } else {
+        merged.environments.remove(target_label);
+    }
+    *state = merged;
+    Ok(())
+}
+
+fn environments_equivalent(a: &EnvironmentStateV7, b: &EnvironmentStateV7) -> bool {
+    // Cheap structural equality via YAML serialization. The state types do
+    // not derive `PartialEq`, and adding it transitively across the resource
+    // graph types would be a much larger surface change.
+    match (serde_yaml::to_string(a), serde_yaml::to_string(b)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        resource_graph::Resource,
+        roblox_resource_manager::{ExperienceInputs, RobloxInputs, RobloxResource},
+    };
+    use tempfile::TempDir;
+
+    fn make_resource(id: &str) -> RobloxResource {
+        RobloxResource::new(
+            id,
+            RobloxInputs::Experience(ExperienceInputs { group_id: None }),
+            &[],
+        )
+    }
+
+    fn state_with_env(label: &str, marker: &str) -> ResourceStateVLatest {
+        let mut state = ResourceStateVLatest {
+            environments: BTreeMap::new(),
+        };
+        state.environments.insert(
+            label.to_owned(),
+            EnvironmentStateV7 {
+                current: vec![make_resource(marker)],
+                deployments: Vec::new(),
+            },
+        );
+        state
+    }
+
+    #[tokio::test]
+    async fn save_state_cas_merges_when_other_env_changed() {
+        let dir = TempDir::new().unwrap();
+        let cfg = StateConfig::Local;
+
+        // Seed: state contains both environments.
+        let mut seed = ResourceStateVLatest {
+            environments: BTreeMap::new(),
+        };
+        seed.environments.insert(
+            "dev".to_owned(),
+            EnvironmentStateV7 {
+                current: vec![make_resource("dev-resource")],
+                deployments: Vec::new(),
+            },
+        );
+        seed.environments.insert(
+            "prod".to_owned(),
+            EnvironmentStateV7 {
+                current: vec![make_resource("prod-resource")],
+                deployments: Vec::new(),
+            },
+        );
+        save_state(dir.path(), &cfg, &seed).await.unwrap();
+
+        // Operation A loads state and prepares to update "prod".
+        let (mut state_a, handle_a) = load_state_from_source(dir.path(), &cfg).await.unwrap();
+        let baseline_prod = state_a.environment("prod").cloned();
+        state_a.ensure_environment_mut("prod").current = vec![make_resource("prod-resource-v2")];
+
+        // Operation B sneaks in a write to "dev" first.
+        let (mut state_b, handle_b) = load_state_from_source(dir.path(), &cfg).await.unwrap();
+        let baseline_dev = state_b.environment("dev").cloned();
+        state_b.ensure_environment_mut("dev").current = vec![make_resource("dev-resource-v2")];
+        save_state_cas(
+            dir.path(),
+            &cfg,
+            &mut state_b,
+            &handle_b,
+            &SaveTarget::new("dev", baseline_dev),
+        )
+        .await
+        .unwrap();
+
+        // Operation A saves: should detect the conflict, merge dev from disk,
+        // and commit prod.
+        save_state_cas(
+            dir.path(),
+            &cfg,
+            &mut state_a,
+            &handle_a,
+            &SaveTarget::new("prod", baseline_prod),
+        )
+        .await
+        .expect("merge save should succeed");
+
+        let (final_state, _) = load_state_from_source(dir.path(), &cfg).await.unwrap();
+        assert_eq!(
+            final_state.environment("prod").unwrap().current[0].get_id(),
+            "prod-resource-v2",
+            "prod should reflect operation A"
+        );
+        assert_eq!(
+            final_state.environment("dev").unwrap().current[0].get_id(),
+            "dev-resource-v2",
+            "dev should reflect operation B"
+        );
+    }
+
+    #[tokio::test]
+    async fn save_state_cas_rejects_same_env_conflict() {
+        let dir = TempDir::new().unwrap();
+        let cfg = StateConfig::Local;
+        save_state(dir.path(), &cfg, &state_with_env("prod", "r0"))
+            .await
+            .unwrap();
+
+        let (mut state_a, handle_a) = load_state_from_source(dir.path(), &cfg).await.unwrap();
+        let baseline_a = state_a.environment("prod").cloned();
+        state_a.ensure_environment_mut("prod").current = vec![make_resource("r1-A")];
+
+        // Operation B updates prod first.
+        let (mut state_b, handle_b) = load_state_from_source(dir.path(), &cfg).await.unwrap();
+        let baseline_b = state_b.environment("prod").cloned();
+        state_b.ensure_environment_mut("prod").current = vec![make_resource("r1-B")];
+        save_state_cas(
+            dir.path(),
+            &cfg,
+            &mut state_b,
+            &handle_b,
+            &SaveTarget::new("prod", baseline_b),
+        )
+        .await
+        .unwrap();
+
+        let err = save_state_cas(
+            dir.path(),
+            &cfg,
+            &mut state_a,
+            &handle_a,
+            &SaveTarget::new("prod", baseline_a),
+        )
+        .await
+        .expect_err("same-env conflict must be rejected");
+        assert!(
+            err.contains("environment 'prod'"),
+            "error should mention the contended environment, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn save_state_cas_succeeds_on_clean_handle() {
+        let dir = TempDir::new().unwrap();
+        let cfg = StateConfig::Local;
+        let mut state = state_with_env("prod", "r0");
+        save_state(dir.path(), &cfg, &state).await.unwrap();
+
+        let (mut loaded, handle) = load_state_from_source(dir.path(), &cfg).await.unwrap();
+        let baseline = loaded.environment("prod").cloned();
+        loaded.ensure_environment_mut("prod").current = vec![make_resource("r1")];
+        // ensure original `state` binding is silenced if unused
+        state = loaded;
+        let _new_handle = save_state_cas(
+            dir.path(),
+            &cfg,
+            &mut state,
+            &handle,
+            &SaveTarget::new("prod", baseline),
+        )
+        .await
+        .unwrap();
+
+        let (after, _) = load_state_from_source(dir.path(), &cfg).await.unwrap();
+        assert_eq!(after.environment("prod").unwrap().current[0].get_id(), "r1");
     }
 }

--- a/src/rbx_lithos/src/state/io.rs
+++ b/src/rbx_lithos/src/state/io.rs
@@ -219,6 +219,30 @@ pub async fn get_previous_state(
     Ok(state)
 }
 
+/// Variant of [`get_previous_state`] that also returns the [`StateHandle`]
+/// captured at load time. Commands use that handle as the CAS expectation
+/// for every subsequent state write.
+pub async fn get_previous_state_with_handle(
+    project_path: &Path,
+    config: &Config,
+    environment_config: &EnvironmentConfig,
+) -> Result<(ResourceStateVLatest, StateHandle), String> {
+    let (mut state, handle) = load_state_with_handle(project_path, config).await?;
+
+    if !state.environments.contains_key(&environment_config.label) {
+        logger::log(format!(
+            "No previous state for environment {}",
+            Paint::cyan(environment_config.label.clone())
+        ));
+        state.environments.insert(
+            environment_config.label.clone(),
+            super::v7::EnvironmentStateV7::default(),
+        );
+    }
+
+    Ok((state, handle))
+}
+
 pub async fn save_state_to_remote(config: &RemoteStateConfig, data: &[u8]) -> Result<(), String> {
     logger::log(format!("Saving to remote object {}", Paint::cyan(config)));
 

--- a/src/rbx_lithos/src/state/io.rs
+++ b/src/rbx_lithos/src/state/io.rs
@@ -115,6 +115,7 @@ pub async fn load_state_from_source(
     let state = match bytes {
         None => ResourceStateVLatest {
             environments: BTreeMap::new(),
+            locks: BTreeMap::new(),
         },
         Some(bytes) => parse_state_bytes(&store_label(source), &bytes)?,
     };
@@ -366,6 +367,7 @@ pub async fn save_state_cas(
                     Some(bytes) => parse_state_bytes(&store_label(state_config), bytes)?,
                     None => ResourceStateVLatest {
                         environments: BTreeMap::new(),
+                        locks: BTreeMap::new(),
                     },
                 };
                 rebase_onto_latest(state, latest_state, target)?;
@@ -466,6 +468,7 @@ mod tests {
     fn state_with_env(label: &str, marker: &str) -> ResourceStateVLatest {
         let mut state = ResourceStateVLatest {
             environments: BTreeMap::new(),
+            locks: BTreeMap::new(),
         };
         state.environments.insert(
             label.to_owned(),
@@ -485,6 +488,7 @@ mod tests {
         // Seed: state contains both environments.
         let mut seed = ResourceStateVLatest {
             environments: BTreeMap::new(),
+            locks: BTreeMap::new(),
         };
         seed.environments.insert(
             "dev".to_owned(),

--- a/src/rbx_lithos/src/state/lock.rs
+++ b/src/rbx_lithos/src/state/lock.rs
@@ -12,11 +12,16 @@
 //! operator can break the lock with the `lithos lock` CLI command (or any
 //! mutating command in `--force` mode in a future iteration).
 
+use std::path::Path;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::config::StateConfig;
+
+use super::io::{load_state_from_source, save_state_cas, ResourceStateVLatest, SaveTarget};
+use super::store::StateHandle;
 use super::v7::ResourceStateV7;
 
 /// Default heartbeat interval used by long-running operations.
@@ -247,6 +252,134 @@ fn hostname() -> String {
     std::env::var("COMPUTERNAME")
         .or_else(|_| std::env::var("HOSTNAME"))
         .unwrap_or_else(|_| "unknown".to_owned())
+}
+
+/// RAII-style handle returned by [`acquire_environment_lock`]. Holds the
+/// owner id that identifies us to the lock metadata in state.
+#[derive(Clone, Debug)]
+pub struct EnvironmentLockSession {
+    pub environment: String,
+    pub owner_id: String,
+    pub operation: String,
+}
+
+/// Format a human-readable diagnostic for a lock currently held by some
+/// other process. Used both when a fresh acquire is blocked and when our
+/// own lock has been broken by an admin.
+pub fn describe_existing_lock(lock: &EnvironmentLock) -> String {
+    format!(
+        "held by pid {} on {} (operation '{}', acquired_at {}, heartbeat {})",
+        lock.pid, lock.host, lock.operation, lock.acquired_at, lock.heartbeat_at
+    )
+}
+
+/// Acquire a lock on `environment` and persist the change via CAS. Returns
+/// an [`EnvironmentLockSession`] the caller threads through subsequent
+/// state writes.
+///
+/// The caller passes a mutable reference to the freshly loaded state plus
+/// the [`StateHandle`] it came with; both are updated on success so that
+/// the next CAS write can resume from the post-lock revision.
+///
+/// On contention this function does not block: if a non-stale lock is
+/// already in place we return an error describing the holder. Stale locks
+/// are reclaimed automatically.
+pub async fn acquire_environment_lock(
+    project_path: &Path,
+    state_config: &StateConfig,
+    state: &mut ResourceStateVLatest,
+    handle: &mut StateHandle,
+    environment: &str,
+    operation: &str,
+) -> Result<EnvironmentLockSession, String> {
+    let owner_id = new_owner_id();
+    let baseline = state.environment(environment).cloned();
+
+    match state.try_acquire_environment_lock(environment, owner_id.clone(), operation.to_owned()) {
+        AcquireOutcome::Acquired(_) => {}
+        AcquireOutcome::Held { existing, is_stale } => {
+            return Err(format!(
+                "Cannot acquire lock for environment '{}': {}{}. Use `lithos lock break --environment {}` to release a stale lock.",
+                environment,
+                describe_existing_lock(&existing),
+                if is_stale { " (stale)" } else { "" },
+                environment,
+            ));
+        }
+    }
+
+    let target = SaveTarget::new(environment, baseline);
+    let new_handle = save_state_cas(project_path, state_config, state, handle, &target)
+        .await
+        .map_err(|e| format!("Failed to persist lock acquisition: {}", e))?;
+    *handle = new_handle;
+
+    Ok(EnvironmentLockSession {
+        environment: environment.to_owned(),
+        owner_id,
+        operation: operation.to_owned(),
+    })
+}
+
+/// Refresh the heartbeat for an already-held lock and persist via CAS.
+/// Returns an error if our lock has been stolen or broken; callers should
+/// treat that as a hard abort.
+pub async fn heartbeat_environment_lock(
+    project_path: &Path,
+    state_config: &StateConfig,
+    state: &mut ResourceStateVLatest,
+    handle: &mut StateHandle,
+    session: &EnvironmentLockSession,
+) -> Result<(), String> {
+    let baseline = state.environment(&session.environment).cloned();
+    state
+        .heartbeat_environment_lock(&session.environment, &session.owner_id)
+        .map_err(|e| e.to_string())?;
+    let target = SaveTarget::new(&session.environment, baseline);
+    let new_handle = save_state_cas(project_path, state_config, state, handle, &target)
+        .await
+        .map_err(|e| format!("Failed to heartbeat lock: {}", e))?;
+    *handle = new_handle;
+    Ok(())
+}
+
+/// Release an environment lock and persist via CAS. Best-effort: if the
+/// caller no longer owns the lock we surface a warning but do not retry.
+pub async fn release_environment_lock(
+    project_path: &Path,
+    state_config: &StateConfig,
+    state: &mut ResourceStateVLatest,
+    handle: &mut StateHandle,
+    session: &EnvironmentLockSession,
+) -> Result<(), String> {
+    let baseline = state.environment(&session.environment).cloned();
+    state
+        .release_environment_lock(&session.environment, &session.owner_id)
+        .map_err(|e| e.to_string())?;
+    let target = SaveTarget::new(&session.environment, baseline);
+    let new_handle = save_state_cas(project_path, state_config, state, handle, &target)
+        .await
+        .map_err(|e| format!("Failed to release lock: {}", e))?;
+    *handle = new_handle;
+    Ok(())
+}
+
+/// Forcibly break a lock for an environment, regardless of ownership.
+/// Intended for the `lithos lock break` CLI subcommand. Returns the lock
+/// that was broken, if any.
+pub async fn force_break_environment_lock(
+    project_path: &Path,
+    state_config: &StateConfig,
+    environment: &str,
+) -> Result<Option<EnvironmentLock>, String> {
+    let (mut state, handle) = load_state_from_source(project_path, state_config).await?;
+    let baseline = state.environment(environment).cloned();
+    let broken = state.force_break_environment_lock(environment);
+    if broken.is_some() {
+        let target = SaveTarget::new(environment, baseline);
+        save_state_cas(project_path, state_config, &mut state, &handle, &target).await?;
+    }
+    Ok(broken)
 }
 
 #[cfg(test)]

--- a/src/rbx_lithos/src/state/lock.rs
+++ b/src/rbx_lithos/src/state/lock.rs
@@ -1,0 +1,314 @@
+//! Environment-scoped advisory locks used to serialize mutating commands.
+//!
+//! Locks live *inside* the state document so the same compare-and-swap
+//! machinery that protects every other state write also protects the lock
+//! itself. Acquiring a lock therefore performs a regular CAS-guarded save,
+//! and any race between two would-be lock holders is resolved at the
+//! store layer.
+//!
+//! A lock carries enough identity (owner id, host, PID, operation, started
+//! time, last heartbeat) to be diagnostically useful and to support stale
+//! lock recovery: if the heartbeat is older than the configured TTL, an
+//! operator can break the lock with the `lithos lock` CLI command (or any
+//! mutating command in `--force` mode in a future iteration).
+
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::v7::ResourceStateV7;
+
+/// Default heartbeat interval used by long-running operations.
+pub const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+/// Default age at which a lock is considered abandoned.
+pub const DEFAULT_LOCK_TTL: Duration = Duration::from_secs(15 * 60);
+
+/// Metadata describing the owner of an environment-scoped lock.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct EnvironmentLock {
+    /// Unique id generated when the lock was acquired. The owning process
+    /// keeps this around so it can prove it still holds the lock when
+    /// renewing or releasing.
+    pub owner_id: String,
+    /// Best-effort host name of the machine that took the lock.
+    pub host: String,
+    /// Process id of the holder.
+    pub pid: u32,
+    /// User-visible label for the operation (e.g. "deploy", "undo").
+    pub operation: String,
+    /// RFC3339 timestamp of when the lock was first acquired.
+    pub acquired_at: String,
+    /// RFC3339 timestamp of the most recent heartbeat. Refreshed on every
+    /// progress write while the lock is held.
+    pub heartbeat_at: String,
+    /// RFC3339 timestamp at which other writers may consider the lock
+    /// abandoned if no fresh heartbeat has been recorded. Currently equal
+    /// to `heartbeat_at + DEFAULT_LOCK_TTL`.
+    pub expires_at: String,
+}
+
+impl EnvironmentLock {
+    /// Construct a fresh lock for the supplied owner/operation.
+    pub fn new(owner_id: String, operation: String) -> Self {
+        let host = hostname();
+        let pid = std::process::id();
+        let now = Utc::now();
+        Self {
+            owner_id,
+            host,
+            pid,
+            operation,
+            acquired_at: now.to_rfc3339(),
+            heartbeat_at: now.to_rfc3339(),
+            expires_at: (now + chrono::Duration::from_std(DEFAULT_LOCK_TTL).unwrap()).to_rfc3339(),
+        }
+    }
+
+    /// Returns true if the lock has not been refreshed within
+    /// [`DEFAULT_LOCK_TTL`].
+    pub fn is_stale(&self) -> bool {
+        match DateTime::parse_from_rfc3339(&self.heartbeat_at) {
+            Ok(parsed) => {
+                let age = Utc::now().signed_duration_since(parsed.with_timezone(&Utc));
+                match age.to_std() {
+                    Ok(age) => age > DEFAULT_LOCK_TTL,
+                    Err(_) => false,
+                }
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Update the lock's heartbeat / expiry to "now". Does not change the
+    /// owner identity, so a heartbeat is a no-op for stale lock recovery.
+    pub fn touch(&mut self) {
+        let now = Utc::now();
+        self.heartbeat_at = now.to_rfc3339();
+        self.expires_at =
+            (now + chrono::Duration::from_std(DEFAULT_LOCK_TTL).unwrap()).to_rfc3339();
+    }
+}
+
+/// Outcome of trying to acquire an environment lock.
+#[derive(Debug)]
+pub enum AcquireOutcome {
+    /// We hold the lock. The returned [`EnvironmentLock`] is also written
+    /// into the state document; callers should now CAS-save the state.
+    Acquired(EnvironmentLock),
+    /// Another holder still owns this environment.
+    Held {
+        existing: EnvironmentLock,
+        is_stale: bool,
+    },
+}
+
+#[derive(Debug)]
+pub enum LockError {
+    /// The expected owner id no longer matches the lock recorded in state.
+    /// This means our lock was broken or stolen by another writer.
+    NotOwner {
+        environment: String,
+        current: Option<Box<EnvironmentLock>>,
+    },
+    /// The environment is not currently locked.
+    NotLocked { environment: String },
+}
+
+impl std::fmt::Display for LockError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LockError::NotOwner {
+                environment,
+                current,
+            } => {
+                write!(
+                    f,
+                    "Lock for environment '{}' is no longer owned by this process",
+                    environment
+                )?;
+                if let Some(lock) = current {
+                    write!(
+                        f,
+                        " (current holder: pid {} on {}, operation '{}')",
+                        lock.pid, lock.host, lock.operation
+                    )?;
+                }
+                Ok(())
+            }
+            LockError::NotLocked { environment } => {
+                write!(f, "Environment '{}' is not currently locked", environment)
+            }
+        }
+    }
+}
+
+impl ResourceStateV7 {
+    /// Look up the lock entry for an environment, if any.
+    pub fn environment_lock(&self, label: &str) -> Option<&EnvironmentLock> {
+        self.locks.get(label)
+    }
+
+    /// Attempt to claim the lock for `label`. If the slot is empty or holds
+    /// a stale lock the new owner takes over; otherwise the caller is told
+    /// who still holds it. The state document is mutated in memory; the
+    /// caller is responsible for persisting via `save_state_cas`.
+    pub fn try_acquire_environment_lock(
+        &mut self,
+        label: &str,
+        owner_id: String,
+        operation: String,
+    ) -> AcquireOutcome {
+        if let Some(existing) = self.locks.get(label).cloned() {
+            if existing.is_stale() {
+                let lock = EnvironmentLock::new(owner_id, operation);
+                self.locks.insert(label.to_owned(), lock.clone());
+                return AcquireOutcome::Acquired(lock);
+            }
+            return AcquireOutcome::Held {
+                existing,
+                is_stale: false,
+            };
+        }
+        let lock = EnvironmentLock::new(owner_id, operation);
+        self.locks.insert(label.to_owned(), lock.clone());
+        AcquireOutcome::Acquired(lock)
+    }
+
+    /// Refresh the heartbeat for a lock we already hold. Returns an error
+    /// if the lock was taken over by someone else.
+    pub fn heartbeat_environment_lock(
+        &mut self,
+        label: &str,
+        owner_id: &str,
+    ) -> Result<(), LockError> {
+        match self.locks.get_mut(label) {
+            Some(lock) if lock.owner_id == owner_id => {
+                lock.touch();
+                Ok(())
+            }
+            Some(_) => Err(LockError::NotOwner {
+                environment: label.to_owned(),
+                current: self.locks.get(label).cloned().map(Box::new),
+            }),
+            None => Err(LockError::NotLocked {
+                environment: label.to_owned(),
+            }),
+        }
+    }
+
+    /// Release a lock we hold. Returns an error if we no longer own it.
+    pub fn release_environment_lock(
+        &mut self,
+        label: &str,
+        owner_id: &str,
+    ) -> Result<(), LockError> {
+        match self.locks.get(label) {
+            Some(lock) if lock.owner_id == owner_id => {
+                self.locks.remove(label);
+                Ok(())
+            }
+            Some(_) => Err(LockError::NotOwner {
+                environment: label.to_owned(),
+                current: self.locks.get(label).cloned().map(Box::new),
+            }),
+            None => Err(LockError::NotLocked {
+                environment: label.to_owned(),
+            }),
+        }
+    }
+
+    /// Forcibly remove a lock regardless of ownership. Intended for
+    /// operator-initiated stale-lock recovery.
+    pub fn force_break_environment_lock(&mut self, label: &str) -> Option<EnvironmentLock> {
+        self.locks.remove(label)
+    }
+
+    /// Iterate over all currently held locks.
+    pub fn iter_environment_locks(&self) -> impl Iterator<Item = (&String, &EnvironmentLock)> {
+        self.locks.iter()
+    }
+}
+
+/// Generate a new opaque owner id. Used by command-line entry points when
+/// they take a lock.
+pub fn new_owner_id() -> String {
+    format!(
+        "{}-{}-{}",
+        hostname(),
+        std::process::id(),
+        Utc::now().timestamp_nanos_opt().unwrap_or(0)
+    )
+}
+
+fn hostname() -> String {
+    // Avoid pulling in a hostname crate for this best-effort field.
+    std::env::var("COMPUTERNAME")
+        .or_else(|_| std::env::var("HOSTNAME"))
+        .unwrap_or_else(|_| "unknown".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn empty_state() -> ResourceStateV7 {
+        ResourceStateV7 {
+            environments: BTreeMap::new(),
+            locks: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn acquires_lock_when_empty() {
+        let mut state = empty_state();
+        match state.try_acquire_environment_lock("prod", "owner-a".to_owned(), "deploy".to_owned())
+        {
+            AcquireOutcome::Acquired(lock) => {
+                assert_eq!(lock.owner_id, "owner-a");
+                assert_eq!(lock.operation, "deploy");
+            }
+            _ => panic!("expected acquire"),
+        }
+        assert!(state.environment_lock("prod").is_some());
+    }
+
+    #[test]
+    fn second_acquire_is_blocked_while_lock_is_fresh() {
+        let mut state = empty_state();
+        let _ =
+            state.try_acquire_environment_lock("prod", "owner-a".to_owned(), "deploy".to_owned());
+        match state.try_acquire_environment_lock("prod", "owner-b".to_owned(), "deploy".to_owned())
+        {
+            AcquireOutcome::Held { existing, is_stale } => {
+                assert_eq!(existing.owner_id, "owner-a");
+                assert!(!is_stale);
+            }
+            _ => panic!("expected held"),
+        }
+    }
+
+    #[test]
+    fn release_requires_ownership() {
+        let mut state = empty_state();
+        let _ =
+            state.try_acquire_environment_lock("prod", "owner-a".to_owned(), "deploy".to_owned());
+        assert!(state.release_environment_lock("prod", "owner-b").is_err());
+        state
+            .release_environment_lock("prod", "owner-a")
+            .expect("rightful owner releases");
+        assert!(state.environment_lock("prod").is_none());
+    }
+
+    #[test]
+    fn force_break_clears_lock() {
+        let mut state = empty_state();
+        let _ =
+            state.try_acquire_environment_lock("prod", "owner-a".to_owned(), "deploy".to_owned());
+        let broken = state.force_break_environment_lock("prod").unwrap();
+        assert_eq!(broken.owner_id, "owner-a");
+        assert!(state.environment_lock("prod").is_none());
+    }
+}

--- a/src/rbx_lithos/src/state/lock.rs
+++ b/src/rbx_lithos/src/state/lock.rs
@@ -444,4 +444,139 @@ mod tests {
         assert_eq!(broken.owner_id, "owner-a");
         assert!(state.environment_lock("prod").is_none());
     }
+
+    #[tokio::test]
+    async fn second_acquire_against_persisted_lock_is_rejected() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let cfg = StateConfig::Local;
+
+        // First acquirer.
+        let (mut state, mut handle) = load_state_from_source(dir.path(), &cfg).await.unwrap();
+        let _session =
+            acquire_environment_lock(dir.path(), &cfg, &mut state, &mut handle, "prod", "deploy")
+                .await
+                .expect("first acquire succeeds");
+
+        // Second acquirer loads fresh state and should see the existing lock.
+        let (mut state_b, mut handle_b) = load_state_from_source(dir.path(), &cfg).await.unwrap();
+        let err = acquire_environment_lock(
+            dir.path(),
+            &cfg,
+            &mut state_b,
+            &mut handle_b,
+            "prod",
+            "deploy",
+        )
+        .await
+        .expect_err("second acquire must be rejected");
+        assert!(
+            err.contains("lithos lock break"),
+            "diagnostic should point at recovery command, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn force_break_then_reacquire_succeeds() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let cfg = StateConfig::Local;
+
+        let (mut state, mut handle) = load_state_from_source(dir.path(), &cfg).await.unwrap();
+        let _ =
+            acquire_environment_lock(dir.path(), &cfg, &mut state, &mut handle, "prod", "deploy")
+                .await
+                .unwrap();
+
+        let broken = force_break_environment_lock(dir.path(), &cfg, "prod")
+            .await
+            .unwrap();
+        assert!(broken.is_some(), "should have broken an existing lock");
+
+        // Reacquire from a fresh load.
+        let (mut state_b, mut handle_b) = load_state_from_source(dir.path(), &cfg).await.unwrap();
+        acquire_environment_lock(
+            dir.path(),
+            &cfg,
+            &mut state_b,
+            &mut handle_b,
+            "prod",
+            "deploy",
+        )
+        .await
+        .expect("reacquire after force_break must succeed");
+    }
+
+    #[tokio::test]
+    async fn force_break_when_no_lock_returns_none() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let cfg = StateConfig::Local;
+        let result = force_break_environment_lock(dir.path(), &cfg, "prod")
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn release_drops_lock_and_unblocks_next_acquirer() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let cfg = StateConfig::Local;
+
+        let (mut state, mut handle) = load_state_from_source(dir.path(), &cfg).await.unwrap();
+        let session =
+            acquire_environment_lock(dir.path(), &cfg, &mut state, &mut handle, "prod", "deploy")
+                .await
+                .unwrap();
+        release_environment_lock(dir.path(), &cfg, &mut state, &mut handle, &session)
+            .await
+            .unwrap();
+
+        let (mut state_b, mut handle_b) = load_state_from_source(dir.path(), &cfg).await.unwrap();
+        acquire_environment_lock(
+            dir.path(),
+            &cfg,
+            &mut state_b,
+            &mut handle_b,
+            "prod",
+            "deploy",
+        )
+        .await
+        .expect("acquire after release should succeed");
+    }
+
+    #[tokio::test]
+    async fn cross_environment_locks_do_not_conflict() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let cfg = StateConfig::Local;
+
+        let (mut state_a, mut handle_a) = load_state_from_source(dir.path(), &cfg).await.unwrap();
+        acquire_environment_lock(
+            dir.path(),
+            &cfg,
+            &mut state_a,
+            &mut handle_a,
+            "dev",
+            "deploy",
+        )
+        .await
+        .unwrap();
+
+        // A second client takes prod from its own freshly-loaded state; this
+        // exercises the cross-env merge path in save_state_cas.
+        let (mut state_b, mut handle_b) = load_state_from_source(dir.path(), &cfg).await.unwrap();
+        acquire_environment_lock(
+            dir.path(),
+            &cfg,
+            &mut state_b,
+            &mut handle_b,
+            "prod",
+            "deploy",
+        )
+        .await
+        .expect("different-environment lock should succeed");
+
+        // Final state on disk should carry both locks.
+        let (final_state, _) = load_state_from_source(dir.path(), &cfg).await.unwrap();
+        assert!(final_state.environment_lock("dev").is_some());
+        assert!(final_state.environment_lock("prod").is_some());
+    }
 }

--- a/src/rbx_lithos/src/state/mod.rs
+++ b/src/rbx_lithos/src/state/mod.rs
@@ -26,13 +26,14 @@ pub use history::{
     build_failure_journal, build_success_journal, latest_deployment_diagnostics, rollback_snapshot,
 };
 pub use io::{
-    get_previous_state, get_state, get_state_from_source, load_state_from_source,
-    load_state_with_handle, save_state, save_state_cas, save_state_to_file, save_state_to_remote,
-    ResourceStateVLatest, SaveTarget,
+    get_previous_state, get_previous_state_with_handle, get_state, get_state_from_source,
+    load_state_from_source, load_state_with_handle, save_state, save_state_cas, save_state_to_file,
+    save_state_to_remote, ResourceStateVLatest, SaveTarget,
 };
 pub use lock::{
-    new_owner_id, AcquireOutcome, EnvironmentLock, LockError, DEFAULT_HEARTBEAT_INTERVAL,
-    DEFAULT_LOCK_TTL,
+    acquire_environment_lock, force_break_environment_lock, heartbeat_environment_lock,
+    new_owner_id, release_environment_lock, AcquireOutcome, EnvironmentLock,
+    EnvironmentLockSession, LockError, DEFAULT_HEARTBEAT_INTERVAL, DEFAULT_LOCK_TTL,
 };
 pub use progress::DeploymentProgressWriter;
 pub use reconcile::{

--- a/src/rbx_lithos/src/state/mod.rs
+++ b/src/rbx_lithos/src/state/mod.rs
@@ -11,6 +11,7 @@ mod io;
 mod legacy_resources;
 mod progress;
 pub mod reconcile;
+pub mod store;
 pub mod v1;
 pub mod v2;
 pub mod v3;
@@ -32,3 +33,4 @@ pub use reconcile::{
     reconcile_graph, reconcile_graph_with_statuses, verify_graph, LiveStateVerifier,
     ReconciliationCounts, ReconciliationReport, RobloxLiveStateVerifier, VerificationStatus,
 };
+pub use store::{build_store, LoadedState, SaveError, StateHandle, StateStore};

--- a/src/rbx_lithos/src/state/mod.rs
+++ b/src/rbx_lithos/src/state/mod.rs
@@ -9,6 +9,7 @@ mod build;
 mod history;
 mod io;
 mod legacy_resources;
+pub mod lock;
 mod progress;
 pub mod reconcile;
 pub mod store;
@@ -28,6 +29,10 @@ pub use io::{
     get_previous_state, get_state, get_state_from_source, load_state_from_source,
     load_state_with_handle, save_state, save_state_cas, save_state_to_file, save_state_to_remote,
     ResourceStateVLatest, SaveTarget,
+};
+pub use lock::{
+    new_owner_id, AcquireOutcome, EnvironmentLock, LockError, DEFAULT_HEARTBEAT_INTERVAL,
+    DEFAULT_LOCK_TTL,
 };
 pub use progress::DeploymentProgressWriter;
 pub use reconcile::{

--- a/src/rbx_lithos/src/state/mod.rs
+++ b/src/rbx_lithos/src/state/mod.rs
@@ -25,8 +25,9 @@ pub use history::{
     build_failure_journal, build_success_journal, latest_deployment_diagnostics, rollback_snapshot,
 };
 pub use io::{
-    get_previous_state, get_state, get_state_from_source, save_state, save_state_to_file,
-    save_state_to_remote, ResourceStateVLatest,
+    get_previous_state, get_state, get_state_from_source, load_state_from_source,
+    load_state_with_handle, save_state, save_state_cas, save_state_to_file, save_state_to_remote,
+    ResourceStateVLatest, SaveTarget,
 };
 pub use progress::DeploymentProgressWriter;
 pub use reconcile::{

--- a/src/rbx_lithos/src/state/progress.rs
+++ b/src/rbx_lithos/src/state/progress.rs
@@ -12,34 +12,43 @@ use crate::{
 
 use super::{
     history::{build_failure_journal, build_success_journal},
-    io::{save_state, ResourceStateVLatest},
+    io::{save_state_cas, ResourceStateVLatest, SaveTarget},
+    lock::{heartbeat_environment_lock, EnvironmentLockSession},
+    store::StateHandle,
 };
 
 pub struct DeploymentProgressWriter<'a> {
     project_path: &'a Path,
     state_config: &'a StateConfig,
     state: &'a mut ResourceStateVLatest,
+    state_handle: &'a mut StateHandle,
     environment_label: &'a str,
     deployment_id: &'a str,
     baseline_graph: &'a ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs>,
+    lock: Option<&'a EnvironmentLockSession>,
 }
 
 impl<'a> DeploymentProgressWriter<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         project_path: &'a Path,
         state_config: &'a StateConfig,
         state: &'a mut ResourceStateVLatest,
+        state_handle: &'a mut StateHandle,
         environment_label: &'a str,
         deployment_id: &'a str,
         baseline_graph: &'a ResourceGraph<RobloxResource, RobloxInputs, RobloxOutputs>,
+        lock: Option<&'a EnvironmentLockSession>,
     ) -> Self {
         Self {
             project_path,
             state_config,
             state,
+            state_handle,
             environment_label,
             deployment_id,
             baseline_graph,
+            lock,
         }
     }
 
@@ -98,6 +107,28 @@ impl EvaluateProgressHandler<RobloxResource, RobloxInputs, RobloxOutputs>
             Some(Self::progress_summary(results, failures)),
         );
 
-        save_state(self.project_path, self.state_config, self.state).await
+        if let Some(session) = self.lock {
+            heartbeat_environment_lock(
+                self.project_path,
+                self.state_config,
+                self.state,
+                self.state_handle,
+                session,
+            )
+            .await?;
+        }
+
+        let baseline = self.state.environment(self.environment_label).cloned();
+        let target = SaveTarget::new(self.environment_label, baseline);
+        let new_handle = save_state_cas(
+            self.project_path,
+            self.state_config,
+            self.state,
+            self.state_handle,
+            &target,
+        )
+        .await?;
+        *self.state_handle = new_handle;
+        Ok(())
     }
 }

--- a/src/rbx_lithos/src/state/store.rs
+++ b/src/rbx_lithos/src/state/store.rs
@@ -1,0 +1,548 @@
+//! Pluggable state-store backends with revision tokens.
+//!
+//! Each backend exposes:
+//! - [`StateStore::load`]: read the raw state bytes (if any) together with a
+//!   [`StateHandle`] that uniquely identifies that revision of the store
+//!   (content hash for local files, ETag + hash for S3).
+//! - [`StateStore::save`]: persist new bytes guarded by the handle that was
+//!   returned at load time. If the on-disk/remote revision has moved since the
+//!   handle was issued, the save fails with [`SaveError::Conflict`] and the
+//!   caller is given the latest [`LoadedState`] so it can merge or retry.
+//!
+//! Higher-level wrappers in [`super::io`] keep the legacy `save_state` API
+//! working by performing a load → save round-trip against the appropriate
+//! store, but mutating commands are expected to thread the handle explicitly
+//! to get real compare-and-swap semantics.
+
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use async_trait::async_trait;
+use rusoto_core::Region;
+use rusoto_s3::{S3Client, S3};
+use sha2::{Digest, Sha256};
+use tokio::io::AsyncReadExt;
+use yansi::Paint;
+
+use crate::config::{RemoteStateConfig, StateConfig};
+
+use super::aws_credentials_provider::AwsCredentialsProvider;
+
+const STATE_SUFFIX: &str = ".lithos-state.yml";
+const LEGACY_STATE_SUFFIX: &str = ".mantle-state.yml";
+
+/// Opaque revision token returned by a [`StateStore`].
+///
+/// Callers must treat this as opaque: hold onto whatever the store handed back
+/// at load time and pass it back unchanged to the matching save. Saves are
+/// only allowed to succeed if the store's current revision still matches.
+#[derive(Debug, Clone)]
+pub struct StateHandle {
+    inner: StateHandleInner,
+}
+
+#[derive(Debug, Clone)]
+enum StateHandleInner {
+    /// The state did not exist when loaded. Only the first write may use this
+    /// handle; once anything has been persisted the store will refuse to
+    /// re-treat the slot as empty.
+    Empty,
+    Existing {
+        content_hash: String,
+        // Reserved for backend-native conditional writes (e.g. S3 If-Match
+        // once we switch off rusoto 0.47). Today only `content_hash` drives
+        // the compare-and-swap check.
+        #[allow(dead_code)]
+        backend_token: Option<String>,
+    },
+}
+
+impl StateHandle {
+    pub fn empty() -> Self {
+        Self {
+            inner: StateHandleInner::Empty,
+        }
+    }
+
+    fn existing(content_hash: String, backend_token: Option<String>) -> Self {
+        Self {
+            inner: StateHandleInner::Existing {
+                content_hash,
+                backend_token,
+            },
+        }
+    }
+
+    /// Returns `true` if this handle was issued for an empty (not-yet-written)
+    /// state slot.
+    pub fn is_empty_slot(&self) -> bool {
+        matches!(self.inner, StateHandleInner::Empty)
+    }
+
+    fn matches(&self, other: &StateHandle) -> bool {
+        match (&self.inner, &other.inner) {
+            (StateHandleInner::Empty, StateHandleInner::Empty) => true,
+            (
+                StateHandleInner::Existing {
+                    content_hash: a, ..
+                },
+                StateHandleInner::Existing {
+                    content_hash: b, ..
+                },
+            ) => a == b,
+            _ => false,
+        }
+    }
+}
+
+/// Result of [`StateStore::load`]: the raw bytes that were stored (if any) and
+/// a [`StateHandle`] identifying that revision.
+pub struct LoadedState {
+    pub bytes: Option<Vec<u8>>,
+    pub handle: StateHandle,
+}
+
+/// Errors that can occur when persisting state via [`StateStore::save`].
+pub enum SaveError {
+    /// The store's current revision did not match the handle the caller
+    /// passed in. The latest state is included so the caller can attempt to
+    /// merge or retry on top of it.
+    Conflict { latest: LoadedState },
+    /// Any non-conflict failure (I/O error, serialization error, network
+    /// failure, etc.). The message is intended to be surfaced to the user.
+    Other(String),
+}
+
+impl From<String> for SaveError {
+    fn from(value: String) -> Self {
+        SaveError::Other(value)
+    }
+}
+
+/// Backend-agnostic interface for loading and saving Lithos state.
+#[async_trait(?Send)]
+pub trait StateStore {
+    /// Load the raw bytes currently stored in this slot together with a
+    /// handle identifying that revision.
+    async fn load(&self) -> Result<LoadedState, String>;
+
+    /// Persist new bytes, refusing to overwrite anything newer than
+    /// `expected`. Returns the handle that identifies the freshly written
+    /// revision so callers can chain further saves.
+    async fn save(&self, bytes: &[u8], expected: &StateHandle) -> Result<StateHandle, SaveError>;
+
+    /// Human-readable description of where this store points. Used in log
+    /// output and error messages.
+    fn describe(&self) -> String;
+}
+
+fn hash_bytes(data: &[u8]) -> String {
+    let digest = Sha256::digest(data);
+    format!("{:x}", digest)
+}
+
+/// Construct a [`StateStore`] for the supplied [`StateConfig`].
+pub fn build_store(project_path: &Path, config: &StateConfig) -> Box<dyn StateStore> {
+    match config {
+        StateConfig::Local => Box::new(LocalFileStateStore::new(project_path, None)),
+        StateConfig::LocalKey(key) => {
+            Box::new(LocalFileStateStore::new(project_path, Some(key.clone())))
+        }
+        StateConfig::Remote(remote) => Box::new(RemoteS3StateStore::new(remote.clone())),
+    }
+}
+
+/// Local-file backed state store.
+///
+/// Saves are guarded with two layers of defence:
+/// 1. A short-lived sidecar lock file (`<state>.lock`) created with
+///    `O_CREAT|O_EXCL` semantics so two processes on the same machine can not
+///    open the write window concurrently.
+/// 2. A content-hash compare-and-swap inside the critical section: if another
+///    writer slipped in between the caller's load and our save, the hash will
+///    no longer match and the save fails with [`SaveError::Conflict`].
+pub struct LocalFileStateStore {
+    path: PathBuf,
+    legacy_path: PathBuf,
+    lock_path: PathBuf,
+}
+
+impl LocalFileStateStore {
+    pub fn new(project_path: &Path, key: Option<String>) -> Self {
+        let key = key.unwrap_or_default();
+        let path = project_path.join(format!("{}{}", key, STATE_SUFFIX));
+        let legacy_path = project_path.join(format!("{}{}", key, LEGACY_STATE_SUFFIX));
+        let lock_path = path.with_extension("yml.lock");
+        Self {
+            path,
+            legacy_path,
+            lock_path,
+        }
+    }
+
+    fn resolved_read_path(&self) -> Option<PathBuf> {
+        if self.path.exists() {
+            Some(self.path.clone())
+        } else if self.legacy_path.exists() {
+            Some(self.legacy_path.clone())
+        } else {
+            None
+        }
+    }
+
+    fn write_atomic(&self, bytes: &[u8]) -> Result<(), String> {
+        if let Some(parent) = self.path.parent() {
+            if !parent.as_os_str().is_empty() {
+                fs::create_dir_all(parent).map_err(|e| {
+                    format!(
+                        "Failed to create parent directory for state file {}: {}",
+                        self.path.display(),
+                        e
+                    )
+                })?;
+            }
+        }
+        let tmp_path = self.path.with_extension("yml.tmp");
+        // Best-effort cleanup of a previous aborted save.
+        let _ = fs::remove_file(&tmp_path);
+        {
+            let mut file = fs::File::create(&tmp_path).map_err(|e| {
+                format!(
+                    "Failed to open temporary state file {}: {}",
+                    tmp_path.display(),
+                    e
+                )
+            })?;
+            file.write_all(bytes).map_err(|e| {
+                format!(
+                    "Failed to write temporary state file {}: {}",
+                    tmp_path.display(),
+                    e
+                )
+            })?;
+            file.sync_all().ok();
+        }
+        // On Windows `fs::rename` refuses to overwrite, so remove first.
+        if cfg!(target_os = "windows") && self.path.exists() {
+            fs::remove_file(&self.path).map_err(|e| {
+                format!(
+                    "Failed to replace existing state file {}: {}",
+                    self.path.display(),
+                    e
+                )
+            })?;
+        }
+        fs::rename(&tmp_path, &self.path)
+            .map_err(|e| format!("Failed to commit state file {}: {}", self.path.display(), e))?;
+        Ok(())
+    }
+}
+
+#[async_trait(?Send)]
+impl StateStore for LocalFileStateStore {
+    async fn load(&self) -> Result<LoadedState, String> {
+        match self.resolved_read_path() {
+            None => Ok(LoadedState {
+                bytes: None,
+                handle: StateHandle::empty(),
+            }),
+            Some(path) => {
+                let bytes = fs::read(&path)
+                    .map_err(|e| format!("Unable to read state file {}: {}", path.display(), e))?;
+                let hash = hash_bytes(&bytes);
+                Ok(LoadedState {
+                    bytes: Some(bytes),
+                    handle: StateHandle::existing(hash, None),
+                })
+            }
+        }
+    }
+
+    async fn save(&self, bytes: &[u8], expected: &StateHandle) -> Result<StateHandle, SaveError> {
+        let guard = LocalLockGuard::acquire(&self.lock_path).map_err(SaveError::Other)?;
+
+        // Re-read inside the critical section so we detect any writer that
+        // slipped in between the caller's load and now.
+        let current = self.load().await.map_err(SaveError::Other)?;
+        if !expected.matches(&current.handle) {
+            drop(guard);
+            return Err(SaveError::Conflict { latest: current });
+        }
+
+        self.write_atomic(bytes).map_err(SaveError::Other)?;
+        // Clean up legacy file once we have committed the modern path at
+        // least once.
+        if self.legacy_path.exists() && self.legacy_path != self.path {
+            let _ = fs::remove_file(&self.legacy_path);
+        }
+        let new_hash = hash_bytes(bytes);
+        drop(guard);
+        Ok(StateHandle::existing(new_hash, None))
+    }
+
+    fn describe(&self) -> String {
+        format!("local file {}", self.path.display())
+    }
+}
+
+/// RAII sidecar-file lock used by [`LocalFileStateStore`].
+struct LocalLockGuard {
+    path: PathBuf,
+}
+
+impl LocalLockGuard {
+    fn acquire(path: &Path) -> Result<Self, String> {
+        const MAX_ATTEMPTS: u32 = 50;
+        const SLEEP_MS: u64 = 100;
+        const STALE_AFTER_SECS: u64 = 5 * 60;
+
+        for attempt in 0..MAX_ATTEMPTS {
+            match fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(path)
+            {
+                Ok(mut file) => {
+                    let pid = std::process::id();
+                    let _ = writeln!(file, "{}", pid);
+                    return Ok(Self {
+                        path: path.to_path_buf(),
+                    });
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    // If the lock file is stale (process died mid-write),
+                    // reclaim it. Otherwise back off and retry.
+                    if let Ok(meta) = fs::metadata(path) {
+                        if let Ok(modified) = meta.modified() {
+                            if let Ok(age) = modified.elapsed() {
+                                if age.as_secs() > STALE_AFTER_SECS {
+                                    logger::log(format!(
+                                        "{} Reclaiming stale local state lock at {} (age {}s)",
+                                        Paint::yellow("warning:"),
+                                        path.display(),
+                                        age.as_secs()
+                                    ));
+                                    let _ = fs::remove_file(path);
+                                    continue;
+                                }
+                            }
+                        }
+                    }
+                    if attempt + 1 == MAX_ATTEMPTS {
+                        return Err(format!(
+                            "Timed out waiting for local state lock {}; another Lithos process \
+                             may be writing state. If the previous process crashed, remove the \
+                             file and retry.",
+                            path.display()
+                        ));
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(SLEEP_MS));
+                }
+                Err(e) => {
+                    return Err(format!(
+                        "Failed to acquire local state lock {}: {}",
+                        path.display(),
+                        e
+                    ));
+                }
+            }
+        }
+        Err(format!(
+            "Unable to acquire local state lock {}",
+            path.display()
+        ))
+    }
+}
+
+impl Drop for LocalLockGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+/// S3-backed state store.
+///
+/// Rusoto 0.47 does not expose `If-Match` for `PutObject`, so this backend
+/// approximates compare-and-swap with a load-then-write pattern: it re-reads
+/// the object inside `save` and compares ETags before writing. There is a
+/// small race window between that check and the write, which is why the
+/// per-environment lock metadata stored *inside* the document is the real
+/// safety net for concurrent mutations. See `docs/site/pages/docs/state.mdx`.
+pub struct RemoteS3StateStore {
+    config: RemoteStateConfig,
+}
+
+impl RemoteS3StateStore {
+    pub fn new(config: RemoteStateConfig) -> Self {
+        Self { config }
+    }
+
+    fn client(&self) -> S3Client {
+        create_client(self.config.region.clone())
+    }
+
+    fn primary_key(&self) -> String {
+        format!("{}.lithos-state.yml", self.config.key)
+    }
+
+    fn legacy_key(&self) -> String {
+        format!("{}.mantle-state.yml", self.config.key)
+    }
+}
+
+fn create_client(region: Region) -> S3Client {
+    S3Client::new_with(
+        rusoto_core::HttpClient::new().expect("failed to construct AWS HTTP client"),
+        AwsCredentialsProvider::new(),
+        region,
+    )
+}
+
+#[async_trait(?Send)]
+impl StateStore for RemoteS3StateStore {
+    async fn load(&self) -> Result<LoadedState, String> {
+        let client = self.client();
+        let keys = [(self.primary_key(), false), (self.legacy_key(), true)];
+
+        for (key, is_legacy) in keys.iter() {
+            let res = client
+                .get_object(rusoto_s3::GetObjectRequest {
+                    bucket: self.config.bucket.clone(),
+                    key: key.clone(),
+                    ..Default::default()
+                })
+                .await;
+
+            match res {
+                Ok(object) => {
+                    if *is_legacy {
+                        logger::log(format!(
+                            "{} Loaded legacy remote state object '{}'. It will be migrated to '{}' on next save.",
+                            Paint::yellow("warning:"),
+                            key,
+                            self.primary_key(),
+                        ));
+                    }
+                    let etag = object.e_tag.clone();
+                    if let Some(stream) = object.body {
+                        let mut buffer = Vec::new();
+                        stream
+                            .into_async_read()
+                            .read_to_end(&mut buffer)
+                            .await
+                            .map_err(|e| format!("Failed to read remote state body: {}", e))?;
+                        let hash = hash_bytes(&buffer);
+                        return Ok(LoadedState {
+                            bytes: Some(buffer),
+                            handle: StateHandle::existing(hash, etag),
+                        });
+                    }
+                    return Ok(LoadedState {
+                        bytes: None,
+                        handle: StateHandle::existing(hash_bytes(&[]), etag),
+                    });
+                }
+                Err(rusoto_core::RusotoError::Service(rusoto_s3::GetObjectError::NoSuchKey(_))) => {
+                    continue
+                }
+                Err(e) => {
+                    return Err(format!("Failed to get state from remote: {}", e));
+                }
+            }
+        }
+
+        Ok(LoadedState {
+            bytes: None,
+            handle: StateHandle::empty(),
+        })
+    }
+
+    async fn save(&self, bytes: &[u8], expected: &StateHandle) -> Result<StateHandle, SaveError> {
+        // Re-read to detect any concurrent writer. This is best effort on
+        // S3: we cannot atomically PUT-if-match through rusoto 0.47, but the
+        // in-document lock metadata still protects mutating workflows.
+        let current = self.load().await.map_err(SaveError::Other)?;
+        if !expected.matches(&current.handle) {
+            return Err(SaveError::Conflict { latest: current });
+        }
+
+        let client = self.client();
+        client
+            .put_object(rusoto_s3::PutObjectRequest {
+                bucket: self.config.bucket.clone(),
+                key: self.primary_key(),
+                body: Some(rusoto_core::ByteStream::from(bytes.to_vec())),
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| SaveError::Other(format!("Failed to save state to remote: {}", e)))?;
+
+        let new_hash = hash_bytes(bytes);
+        Ok(StateHandle::existing(new_hash, None))
+    }
+
+    fn describe(&self) -> String {
+        format!(
+            "remote object {}/{}",
+            self.config.bucket,
+            self.primary_key()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_store(dir: &TempDir) -> LocalFileStateStore {
+        LocalFileStateStore::new(dir.path(), None)
+    }
+
+    #[tokio::test]
+    async fn load_returns_empty_handle_when_no_state_file_exists() {
+        let dir = TempDir::new().unwrap();
+        let store = make_store(&dir);
+        let loaded = store.load().await.unwrap();
+        assert!(loaded.bytes.is_none());
+        assert!(loaded.handle.is_empty_slot());
+    }
+
+    #[tokio::test]
+    async fn first_save_writes_when_expected_is_empty() {
+        let dir = TempDir::new().unwrap();
+        let store = make_store(&dir);
+        let handle = store
+            .save(b"hello", &StateHandle::empty())
+            .await
+            .unwrap_or_else(|_| panic!("first save should succeed"));
+        assert!(!handle.is_empty_slot());
+
+        let loaded = store.load().await.unwrap();
+        assert_eq!(loaded.bytes.as_deref(), Some(&b"hello"[..]));
+    }
+
+    #[tokio::test]
+    async fn save_conflicts_when_handle_is_stale() {
+        let dir = TempDir::new().unwrap();
+        let store = make_store(&dir);
+        let stale = store
+            .save(b"v1", &StateHandle::empty())
+            .await
+            .unwrap_or_else(|_| panic!("seed save failed"));
+        let _ = store
+            .save(b"v2", &stale)
+            .await
+            .unwrap_or_else(|_| panic!("second save failed"));
+
+        match store.save(b"v3", &stale).await {
+            Err(SaveError::Conflict { latest }) => {
+                assert_eq!(latest.bytes.as_deref(), Some(&b"v2"[..]));
+            }
+            _ => panic!("expected conflict when re-using a stale handle"),
+        }
+    }
+}

--- a/src/rbx_lithos/src/state/v7.rs
+++ b/src/rbx_lithos/src/state/v7.rs
@@ -9,6 +9,7 @@ use crate::{
     roblox_resource_manager::{RobloxInputs, RobloxOutputs, RobloxResource},
 };
 
+use super::lock::EnvironmentLock;
 use super::v6::ResourceStateV6;
 
 const MAX_DEPLOYMENT_HISTORY: usize = 10;
@@ -16,6 +17,11 @@ const MAX_DEPLOYMENT_HISTORY: usize = 10;
 #[derive(Serialize, Deserialize, Clone)]
 pub struct ResourceStateV7 {
     pub environments: BTreeMap<String, EnvironmentStateV7>,
+    /// Advisory locks held by mutating commands, keyed by environment label.
+    /// Defaulted so v7 documents written before locks were introduced
+    /// continue to parse.
+    #[serde(default)]
+    pub locks: BTreeMap<String, EnvironmentLock>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -96,6 +102,7 @@ impl From<ResourceStateV6> for ResourceStateV7 {
                     )
                 })
                 .collect(),
+            locks: BTreeMap::new(),
         }
     }
 }
@@ -302,6 +309,7 @@ mod tests {
     fn prefers_latest_rollback_record() {
         let mut state = ResourceStateV7 {
             environments: BTreeMap::new(),
+            locks: BTreeMap::new(),
         };
         let baseline = vec![resource("baseline")];
         let desired = vec![resource("desired")];
@@ -352,6 +360,7 @@ mod tests {
                     deployments: Vec::new(),
                 },
             )]),
+            locks: BTreeMap::new(),
         };
 
         let deployment_id = state.begin_deployment(


### PR DESCRIPTION
This pull request introduces Lithos version 0.4.0, with a major new feature: robust per-environment concurrency control for mutating commands. Lithos now uses compare-and-swap (CAS) state writes and in-state environment locks to prevent concurrent operations from corrupting state, with CLI tools for lock inspection and recovery. Documentation and version references have been updated throughout the project to reflect this release.

**Concurrency and State Management Enhancements:**

* Added per-environment concurrency control for `deploy`, `undo`, `destroy`, and `import` commands. State writes now use compare-and-swap (CAS); cross-environment conflicts auto-merge, while same-environment conflicts abort. [[1]](diffhunk://#diff-de308f736de49213125ec5ba73d749dbb41389580442ae6ebd295a2cfe362696L13-R15) [[2]](diffhunk://#diff-de308f736de49213125ec5ba73d749dbb41389580442ae6ebd295a2cfe362696R350-R413) [[3]](diffhunk://#diff-de308f736de49213125ec5ba73d749dbb41389580442ae6ebd295a2cfe362696L475-R562) [[4]](diffhunk://#diff-a7ae52f49f9f13b26bfaa9ae8c8c067b732c6a842f1d54ae5e3df5c3d94ca041L10-R10) [[5]](diffhunk://#diff-a7ae52f49f9f13b26bfaa9ae8c8c067b732c6a842f1d54ae5e3df5c3d94ca041R43-R59) [[6]](diffhunk://#diff-a7ae52f49f9f13b26bfaa9ae8c8c067b732c6a842f1d54ae5e3df5c3d94ca041L83-R146) [[7]](diffhunk://#diff-45bcdba6010902d0ce295b1b2d7efea0c81fd9d02ee43fe2ebda5401652ece25L10-R13) [[8]](diffhunk://#diff-45bcdba6010902d0ce295b1b2d7efea0c81fd9d02ee43fe2ebda5401652ece25R28)
* Environment-scoped locks are now stored in the state file, with heartbeats and automatic stale-lock recovery. Lock acquisition and release is integrated into all mutating commands. [[1]](diffhunk://#diff-de308f736de49213125ec5ba73d749dbb41389580442ae6ebd295a2cfe362696R350-R413) [[2]](diffhunk://#diff-de308f736de49213125ec5ba73d749dbb41389580442ae6ebd295a2cfe362696L475-R562) [[3]](diffhunk://#diff-a7ae52f49f9f13b26bfaa9ae8c8c067b732c6a842f1d54ae5e3df5c3d94ca041R43-R59) [[4]](diffhunk://#diff-a7ae52f49f9f13b26bfaa9ae8c8c067b732c6a842f1d54ae5e3df5c3d94ca041L83-R146) [[5]](diffhunk://#diff-45bcdba6010902d0ce295b1b2d7efea0c81fd9d02ee43fe2ebda5401652ece25L10-R13)
* New CLI subcommands `lithos lock list` and `lithos lock break --environment <env>` allow users to inspect and forcibly release environment locks, aiding recovery from crashed or stuck runs. [[1]](diffhunk://#diff-00845f231c4eb476b85b6a6720e4cfa72507ef29391ca2a255f863568403afc9R240-R269) [[2]](diffhunk://#diff-00845f231c4eb476b85b6a6720e4cfa72507ef29391ca2a255f863568403afc9R383-R395)

**Documentation Updates:**

* Added detailed documentation on the new concurrency model, including how locks and CAS writes work, practical consequences, and recovery procedures. [[1]](diffhunk://#diff-c1603ee6a674bb75255aa448057630506153e363297fd58668e6679f10909bc6R48-R75) [[2]](diffhunk://#diff-6b2dd06459bf10e2f3cfe4d69c6dc5401874fc268f46d00a16d0f0abb1034786R124-R194)
* Updated migration and usage guides to reference the new concurrency features and CLI commands. [[1]](diffhunk://#diff-c1603ee6a674bb75255aa448057630506153e363297fd58668e6679f10909bc6R48-R75) [[2]](diffhunk://#diff-6b2dd06459bf10e2f3cfe4d69c6dc5401874fc268f46d00a16d0f0abb1034786R124-R194)

**Version and Reference Updates:**

* Bumped Lithos version to 0.4.0 in all relevant files, including `Cargo.toml`, `foreman.toml` examples, documentation, and UI. [[1]](diffhunk://#diff-f761eb849d35191a4809c39e1baa4b54c996875a38d9f3f248fe8485618f1772L3-R3) [[2]](diffhunk://#diff-d00473f38751d2c862c7177e768a5676e830ee0faade6b5180ec2b834151421aL4-R4) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23) [[4]](diffhunk://#diff-d4005d9b869dca8ca8e12ec68b054539d790bb35e64b4e55cbc05eb401354e41L125-R125) [[5]](diffhunk://#diff-88ceb6ac4d531b2c19dc7e186c76e5cfb2f11e005aee1cb63d8d98b1088652cdL65-R65) [[6]](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efL153-R153) [[7]](diffhunk://#diff-afc3efeeefc9225192ed54e371e0aedb3f2fea6709f6a9f9bc8fce4709e295d5L3-L7)

**Changelog:**

* Updated the changelog to summarize the new concurrency features and lock management CLI.